### PR TITLE
Test additional unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 
 .vscode
 yarn-error.log
+
+*.code-workspace

--- a/__tests__/unit-tests/MediaService.ts
+++ b/__tests__/unit-tests/MediaService.ts
@@ -30,16 +30,22 @@ describe('MediaService', () => {
 	describe('Router', () => {
 		const ERROR_MSG_NO_MEDIA_NODES = 'no media nodes available';
 		const ERROR_MSG_ROOM_CLOSED = 'room closed';
-		let fakeMediaNode: MediaNode;
+		let fakeMediaNode1: MediaNode;
+		let fakeMediaNode2: MediaNode;
+		let mockGetRouter1: jest.SpyInstance;
+		let mockGetRouter2: jest.SpyInstance;
+		let spyMediaNode1GetRouter: jest.SpyInstance;
+		let spyMediaNode2GetRouter: jest.SpyInstance;
 		let fakeRoom: Room;
 		let fakePeer: Peer;
 		let spyRoomAddRouter: jest.SpyInstance;
-		let mockGetRouter: jest.SpyInstance;
 
 		beforeEach(() => {
-			mockGetRouter = jest.fn().mockImplementation(async () => {	
-				return { id: 'id',
-					close: jest.fn() } as unknown as Router;
+			mockGetRouter1 = jest.fn().mockImplementation(async () => {	
+				return { close: jest.fn() } as unknown as Router;
+			});
+			mockGetRouter2 = jest.fn().mockImplementation(async () => {	
+				return { close: jest.fn() } as unknown as Router;
 			});
 			fakeRoom = {
 				id: 'id',
@@ -49,14 +55,19 @@ describe('MediaService', () => {
 			fakePeer = {
 				id: 'id'
 			} as unknown as Peer;
-			fakeMediaNode = {
-				getRouter: mockGetRouter
+			fakeMediaNode1 = {
+				getRouter: mockGetRouter1
+			} as unknown as MediaNode;
+			fakeMediaNode2 = {
+				getRouter: mockGetRouter2
 			} as unknown as MediaNode;
 			spyRoomAddRouter = jest.spyOn(fakeRoom, 'addRouter');
+			spyMediaNode1GetRouter = jest.spyOn(fakeMediaNode1, 'getRouter');
+			spyMediaNode2GetRouter = jest.spyOn(fakeMediaNode2, 'getRouter');
 		});
 
 		it('getRouter() - Should add router to room when parent not closed', async () => {
-			mediaService.mediaNodes.add(fakeMediaNode);
+			mediaService.mediaNodes.add(fakeMediaNode1);
 			expect(mediaService.mediaNodes.length).toBe(1);
 			
 			await mediaService.getRouter(fakeRoom, fakePeer);
@@ -67,11 +78,22 @@ describe('MediaService', () => {
 		it('getRouter() - Should throw when parent room have closed', async () => {
 			const roomWithClosedParent = { ...fakeRoom, parentClosed: true } as unknown as Room;
 
-			mediaService.mediaNodes.add(fakeMediaNode);
+			mediaService.mediaNodes.add(fakeMediaNode1);
 			
 			await expect(mediaService.getRouter(roomWithClosedParent, fakePeer)).
 				rejects.toThrowError(ERROR_MSG_ROOM_CLOSED);
 			expect(spyRoomAddRouter).not.toHaveBeenCalled();
+		});
+		
+		it('getRouter() - Should spread routers across mediaNodes', async () => {
+			mediaService.mediaNodes.add(fakeMediaNode1);
+			mediaService.mediaNodes.add(fakeMediaNode2);
+			
+			mediaService.getRouter(fakeRoom, fakePeer);
+			mediaService.getRouter(fakeRoom, fakePeer);
+
+			expect(spyMediaNode1GetRouter).toHaveBeenCalledTimes(1);
+			expect(spyMediaNode2GetRouter).toHaveBeenCalledTimes(1);
 		});
 		
 		// This needs to be last since index is set to NaN

--- a/__tests__/unit-tests/MediaService.ts
+++ b/__tests__/unit-tests/MediaService.ts
@@ -1,11 +1,16 @@
 import 'jest';
+import { Router } from '../../src/media/Router';
 import MediaService from '../../src/MediaService';
+import Room from '../../src/Room';
+import { Peer } from '../../src/Peer';
+import MediaNode from '../../src/media/MediaNode';
 
 describe('MediaService', () => {
 	let mediaService: MediaService;
 
 	beforeEach(() => {
 		mediaService = new MediaService();
+		mediaService.mediaNodes.clear(); // We don't want nodes from config
 	});
 
 	afterEach(() => {
@@ -20,5 +25,59 @@ describe('MediaService', () => {
 		mediaService.close();
 		expect(mediaService.closed).toBe(true);
 		expect(mediaService.mediaNodes.length).toBe(0);
+	});
+
+	describe('Router', () => {
+		const ERROR_MSG_NO_MEDIA_NODES = 'no media nodes available';
+		const ERROR_MSG_ROOM_CLOSED = 'room closed';
+		let fakeMediaNode: MediaNode;
+		let fakeRoom: Room;
+		let fakePeer: Peer;
+		let spyRoomAddRouter: jest.SpyInstance;
+		let mockGetRouter: jest.SpyInstance;
+
+		beforeEach(() => {
+			mockGetRouter = jest.fn().mockImplementation(async () => {	
+				return { id: 'id',
+					close: jest.fn() } as unknown as Router;
+			});
+			fakeRoom = {
+				id: 'id',
+				parentClose: false,
+				addRouter: jest.fn()
+			} as unknown as Room;
+			fakePeer = {
+				id: 'id'
+			} as unknown as Peer;
+			fakeMediaNode = {
+				getRouter: mockGetRouter
+			} as unknown as MediaNode;
+			spyRoomAddRouter = jest.spyOn(fakeRoom, 'addRouter');
+		});
+
+		it('getRouter() - Should add router to room when parent not closed', async () => {
+			mediaService.mediaNodes.add(fakeMediaNode);
+			expect(mediaService.mediaNodes.length).toBe(1);
+			
+			await mediaService.getRouter(fakeRoom, fakePeer);
+
+			expect(spyRoomAddRouter).toHaveBeenCalled();
+		});
+		
+		it('getRouter() - Should throw when parent room have closed', async () => {
+			const roomWithClosedParent = { ...fakeRoom, parentClosed: true } as unknown as Room;
+
+			mediaService.mediaNodes.add(fakeMediaNode);
+			
+			await expect(mediaService.getRouter(roomWithClosedParent, fakePeer)).
+				rejects.toThrowError(ERROR_MSG_ROOM_CLOSED);
+			expect(spyRoomAddRouter).not.toHaveBeenCalled();
+		});
+		
+		// This needs to be last since index is set to NaN
+		it('getRouter() - Should throw on no mediaNodes', async () => {
+			await expect(mediaService.getRouter(fakeRoom, fakePeer)).
+				rejects.toThrowError(ERROR_MSG_NO_MEDIA_NODES);
+		});
 	});
 });

--- a/__tests__/unit-tests/Peer.ts
+++ b/__tests__/unit-tests/Peer.ts
@@ -3,6 +3,9 @@ import 'jest';
 import { Socket } from 'socket.io';
 import { userRoles } from '../../src/common/authorization';
 import { Peer } from '../../src/Peer';
+import { Producer } from '../../src/media/Producer';
+import { Consumer } from '../../src/media/Consumer';
+import { WebRtcTransport } from '../../src/media/WebRtcTransport';
 
 describe('Peer', () => {
 	let connection: BaseConnection;
@@ -65,6 +68,42 @@ describe('Peer', () => {
 		expect(peer.consumers.size).toBe(0);
 		expect(peer.transports.size).toBe(0);
 		expect(spyEmit).toHaveBeenCalledTimes(1);
+	});
+
+	it('close() - should close producers', async () => {
+		const producerToClose = {
+			id: 1,
+			close: jest.fn()
+		} as unknown as Producer;
+		const spyCloseProducer = jest.spyOn(producerToClose, 'close');
+
+		peer.producers.set(producerToClose.id, producerToClose);
+		peer.close();
+		expect(spyCloseProducer).toHaveBeenCalled();
+	});
+
+	it('close() - should close consumers', async () => {
+		const consumerToClose = {
+			id: 'id',
+			close: jest.fn()
+		} as unknown as Consumer;
+		const spyCloseConsumer = jest.spyOn(consumerToClose, 'close');
+
+		peer.consumers.set(consumerToClose.id, consumerToClose);
+		peer.close();
+		expect(spyCloseConsumer).toHaveBeenCalled();
+	});
+
+	it('close() - should close transports', async () => {
+		const transportToClose = {
+			id: 'id',
+			close: jest.fn()
+		} as unknown as WebRtcTransport;
+		const spyCloseTransport = jest.spyOn(transportToClose, 'close');
+
+		peer.transports.set(transportToClose.id, transportToClose);
+		peer.close();
+		expect(spyCloseTransport).toHaveBeenCalled();
 	});
 
 	it('set raisedHand()', () => {

--- a/__tests__/unit-tests/Peer.ts
+++ b/__tests__/unit-tests/Peer.ts
@@ -1,13 +1,33 @@
-import { BaseConnection, IOServerConnection } from 'edumeet-common';
+const mockLoggerDebug = jest.fn();
+const mockLoggerError= jest.fn();
+const mockLoggerWarn= jest.fn();
+
+jest.mock('edumeet-common', () => {
+	const originalModule = jest.requireActual('edumeet-common');
+	
+	return {
+		...originalModule,
+		Logger: jest.fn().mockImplementation(() => {
+			return {
+				debug: mockLoggerDebug,
+				error: mockLoggerError,
+				warn: mockLoggerWarn
+			};
+		})
+	}; 
+});
+
+import { BaseConnection, IOServerConnection, SocketMessage } from 'edumeet-common';
 import 'jest';
 import { Socket } from 'socket.io';
 import { userRoles } from '../../src/common/authorization';
-import { Peer } from '../../src/Peer';
+import { Peer, PeerContext } from '../../src/Peer';
 import { Producer } from '../../src/media/Producer';
 import { Consumer } from '../../src/media/Consumer';
 import { WebRtcTransport } from '../../src/media/WebRtcTransport';
 import { Router } from '../../src/media/Router';
 import EventEmitter from 'events';
+import { Pipeline } from 'edumeet-common';
 
 describe('Peer', () => {
 	let connection: BaseConnection;
@@ -161,28 +181,7 @@ describe('Peer', () => {
 		expect(spyEmit).toHaveBeenCalledTimes(0);
 	});
 
-	it('addConnection()', () => {
-		const connection2 = new IOServerConnection(mockSocket);
-
-		expect(peer.connections.items.length).toBe(1);
-
-		peer.addConnection(connection2);
-
-		expect(peer.connections.items.length).toBe(2);
-	});
-
-	it('addConnection() - handle close', () => {
-		const spyClose = jest.spyOn(peer, 'close');
-
-		expect(peer.connections.length).toBe(1);
-
-		connection.close();
-
-		expect(peer.connections.length).toBe(0);
-		expect(spyClose).toHaveBeenCalled();
-	});
-
-	describe('router', () => {
+	describe('Router', () => {
 		let router: Router;
 
 		beforeEach(() => {
@@ -213,6 +212,131 @@ describe('Peer', () => {
 			emitRouter.emit('close');
 		
 			expect(peer.router).toBe(undefined);
+		});
+	});
+
+	describe('Connections', () => {
+		let DEBUG_MSG_ADD_CONNECTION: string;
+		let REJECT_MESSAGE_SERVER_ERROR: string;
+		let pipelineWithMiddleware: Pipeline<PeerContext>;
+		let pipelineWithoutMiddleware: Pipeline<PeerContext>;
+		let mockRequest: jest.SpyInstance; 
+		let mockRespond: jest.SpyInstance;  
+		let mockReject: jest.SpyInstance;  
+		let spyPipelineExecute: jest.SpyInstance;
+		let spyRequest: jest.SpyInstance;
+		let mockSocketMessage: SocketMessage;
+
+		beforeAll(() => {
+			DEBUG_MSG_ADD_CONNECTION = 'addConnection()';
+			REJECT_MESSAGE_SERVER_ERROR = 'Server error';
+		});
+		
+		beforeEach(() => {
+			mockSocketMessage = {
+			} as unknown as SocketMessage;
+			pipelineWithoutMiddleware = {
+				execute: (context: PeerContext) => {
+					context.handled = false; 
+				}
+			} as unknown as Pipeline<PeerContext>;
+			pipelineWithMiddleware = {
+				execute: (context: PeerContext) => {
+					context.handled = true; 
+				}
+			} as unknown as Pipeline<PeerContext>;
+			mockRequest = jest.fn();
+			mockRespond = jest.fn();
+			mockReject = jest.fn();
+			spyPipelineExecute = jest.spyOn(peer.pipeline, 'execute');
+			spyRequest = jest.spyOn(connection, 'request');
+		});
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('addConnection() - should increment connection count', () => {
+			const connection2 = new IOServerConnection(mockSocket);
+
+			expect(peer.connections.items.length).toBe(1);
+
+			peer.addConnection(connection2);
+
+			expect(peer.connections.items.length).toBe(2);
+		});
+
+		it('addConnection() - handle close', () => {
+			const spyClose = jest.spyOn(peer, 'close');
+
+			expect(peer.connections.length).toBe(1);
+
+			connection.close();
+
+			expect(peer.connections.length).toBe(0);
+			expect(spyClose).toHaveBeenCalled();
+		});
+
+		it('addConnection() - should execute pipeline on events', async () => {
+			const mockNotification = jest.fn();
+
+			await connection.emit('notification', mockNotification);
+			
+			expect(mockLoggerDebug).toHaveBeenCalledWith(DEBUG_MSG_ADD_CONNECTION);
+			expect(spyPipelineExecute).toHaveBeenCalledTimes(1);
+		});
+
+		it('addConnection() - notification event: should throw and catch when not handled by middleware', async () => {
+			peer.pipeline = pipelineWithoutMiddleware;
+
+			await connection.emit('notification');
+			expect(mockLoggerError).toHaveBeenCalledTimes(1);
+		});
+		
+		it('addConnection() - notification event: should not throw and catch when handled by middleware', async () => {
+			peer.pipeline = pipelineWithMiddleware;
+
+			await connection.emit('notification');
+			expect(mockLoggerError).not.toHaveBeenCalled();
+		});
+		
+		it('addConnection() - request event: should not call reject when handled by middleware', async () => {
+			peer.pipeline = pipelineWithMiddleware;
+
+			await connection.emit('request', mockRequest, mockRespond, mockReject);
+
+			expect(mockRespond).toHaveBeenCalledTimes(1);
+			expect(mockReject).not.toHaveBeenCalled();
+		});
+
+		it('addConnection() - request event: should call reject when not handled by middleware', async () => {
+			peer.pipeline = pipelineWithoutMiddleware;
+
+			await connection.emit('request', mockRequest, mockRespond, mockReject);
+
+			expect(mockReject).toHaveBeenNthCalledWith(1, REJECT_MESSAGE_SERVER_ERROR);
+		});
+
+		it('request() - should call request on connections', () => {
+			peer.pipeline = pipelineWithoutMiddleware;
+			peer.addConnection(connection);
+			
+			expect(spyRequest).not.toHaveBeenCalled();
+
+			peer.request(mockSocketMessage);
+
+			expect(spyRequest).toHaveBeenCalled();
+		});
+		
+		it('request() - should log warn on no connections', () => {
+			peer.pipeline = pipelineWithoutMiddleware;
+
+			peer.connections.remove(connection);
+			expect(peer.connections.length).toBe(0);
+			
+			peer.request(mockSocketMessage);
+
+			expect(mockLoggerWarn).toHaveBeenCalled();
 		});
 	});
 });

--- a/__tests__/unit-tests/Peer.ts
+++ b/__tests__/unit-tests/Peer.ts
@@ -6,6 +6,8 @@ import { Peer } from '../../src/Peer';
 import { Producer } from '../../src/media/Producer';
 import { Consumer } from '../../src/media/Consumer';
 import { WebRtcTransport } from '../../src/media/WebRtcTransport';
+import { Router } from '../../src/media/Router';
+import EventEmitter from 'events';
 
 describe('Peer', () => {
 	let connection: BaseConnection;
@@ -178,5 +180,39 @@ describe('Peer', () => {
 
 		expect(peer.connections.length).toBe(0);
 		expect(spyClose).toHaveBeenCalled();
+	});
+
+	describe('router', () => {
+		let router: Router;
+
+		beforeEach(() => {
+			router = {
+				close: jest.fn(),
+				once: jest.fn()
+			} as unknown as Router;
+		});
+
+		it('getter should return undefined when no router', () => {
+			expect(peer.router).toBe(undefined);
+		});
+
+		it('getter should return router when set', () => {
+			peer.router = router;
+			expect(peer.router).toEqual(router);
+		});
+
+		it('should not throw on undefined as argument', () => {
+			expect(() => { peer.router = undefined; }).not.toThrow();
+		});
+
+		it('should set router to undefined on close event', () => {
+			const emitRouter = new EventEmitter();
+
+			peer.router = emitRouter as Router;
+			expect(peer.router).toBe(emitRouter);
+			emitRouter.emit('close');
+		
+			expect(peer.router).toBe(undefined);
+		});
 	});
 });

--- a/__tests__/unit-tests/Peer.ts
+++ b/__tests__/unit-tests/Peer.ts
@@ -216,8 +216,8 @@ describe('Peer', () => {
 	});
 
 	describe('Connections', () => {
-		let DEBUG_MSG_ADD_CONNECTION: string;
-		let REJECT_MESSAGE_SERVER_ERROR: string;
+		const DEBUG_MSG_ADD_CONNECTION = 'addConnection()';
+		const REJECT_MESSAGE_SERVER_ERROR = 'Server error';
 		let pipelineWithMiddleware: Pipeline<PeerContext>;
 		let pipelineWithoutMiddleware: Pipeline<PeerContext>;
 		let mockRequest: jest.SpyInstance; 
@@ -226,11 +226,6 @@ describe('Peer', () => {
 		let spyPipelineExecute: jest.SpyInstance;
 		let spyRequest: jest.SpyInstance;
 		let mockSocketMessage: SocketMessage;
-
-		beforeAll(() => {
-			DEBUG_MSG_ADD_CONNECTION = 'addConnection()';
-			REJECT_MESSAGE_SERVER_ERROR = 'Server error';
-		});
 		
 		beforeEach(() => {
 			mockSocketMessage = {

--- a/__tests__/unit-tests/Room.ts
+++ b/__tests__/unit-tests/Room.ts
@@ -3,9 +3,11 @@ import 'jest';
 import MediaService from '../../src/MediaService';
 import { Peer, PeerContext } from '../../src/Peer';
 import Room from '../../src/Room';
+import { Router } from '../../src/media/Router';
+
 
 describe('Room', () => {
-	let room: Room;
+	let room1: Room;
 	let spyEmit: jest.SpyInstance;
 	let spyNotifyPeers: jest.SpyInstance;
 	let spyAddPeer: jest.SpyInstance;
@@ -14,71 +16,88 @@ describe('Room', () => {
 	let spyRemovePendingPeer: jest.SpyInstance;
 	let spyAddLobbyPeer: jest.SpyInstance;
 	let spyRemoveLobbyPeer: jest.SpyInstance;
-	const roomId = 'testRoom';
-	const roomName = 'testRoomName';
+	let spyAddRoom: jest.SpyInstance;
+	let spyRemoveRoom: jest.SpyInstance;
+	const roomId1 = 'testRoom1';
+	const roomId2 = 'testRoom2';
+	const roomId3 = 'testRoom3';
+	const roomName1 = 'testRoomName1';
+	const roomName2 = 'testRoomName2';
+	const roomName3 = 'testRoomName3';
+
+	const router = {
+		mediaNode: jest.fn(),
+		connection: jest.fn(),
+		id: jest.fn(),
+		rtpCapabilities: jest.fn(),
+		appData: {}
+	} as unknown as Router
+
 
 	beforeEach(() => {
-		room = new Room({
-			id: roomId,
+		room1 = new Room({
+			id: roomId1,
 			mediaService: new MediaService(),
-			name: roomName,
+			name: roomName1,
 		});
 
-		spyEmit = jest.spyOn(room, 'emit');
-		spyNotifyPeers = jest.spyOn(room, 'notifyPeers');
-		spyAddPeer = jest.spyOn(room.peers, 'add');
-		spyRemovePeer = jest.spyOn(room.peers, 'remove');
-		spyAddPendingPeer = jest.spyOn(room.pendingPeers, 'add');
-		spyRemovePendingPeer = jest.spyOn(room.pendingPeers, 'remove');
-		spyAddLobbyPeer = jest.spyOn(room.lobbyPeers, 'add');
-		spyRemoveLobbyPeer = jest.spyOn(room.lobbyPeers, 'remove');
+		spyEmit = jest.spyOn(room1, 'emit');
+		spyNotifyPeers = jest.spyOn(room1, 'notifyPeers');
+		spyAddPeer = jest.spyOn(room1.peers, 'add');
+		spyRemovePeer = jest.spyOn(room1.peers, 'remove');
+		spyAddPendingPeer = jest.spyOn(room1.pendingPeers, 'add');
+		spyRemovePendingPeer = jest.spyOn(room1.pendingPeers, 'remove');
+		spyAddLobbyPeer = jest.spyOn(room1.lobbyPeers, 'add');
+		spyRemoveLobbyPeer = jest.spyOn(room1.lobbyPeers, 'remove');
+		spyAddRoom = jest.spyOn(room1.rooms, 'add')
+		spyRemoveRoom = jest.spyOn(room1.rooms, 'remove')
 	});
 
 	it('Has correct properties', () => {
-		expect(room).toBeInstanceOf(Room);
-		expect(room.id).toBe(roomId);
-		expect(room.name).toBe(roomName);
-		expect(room.sessionId).toBeDefined();
-		expect(room.closed).toBe(false);
-		expect(room.locked).toBe(false);
+		expect(room1).toBeInstanceOf(Room);
+		expect(room1.id).toBe(roomId1);
+		expect(room1.name).toBe(roomName1);
+		expect(room1.sessionId).toBeDefined();
+		expect(room1.closed).toBe(false);
+		expect(room1.locked).toBe(false);
 
-		expect(room.routers.length).toBe(0);
-		expect(room.rooms.length).toBe(0);
-		expect(room.pendingPeers.length).toBe(0);
-		expect(room.peers.length).toBe(0);
-		expect(room.lobbyPeers.length).toBe(0);
+		expect(room1.routers.length).toBe(0);
+		expect(room1.rooms.length).toBe(0);
+		expect(room1.pendingPeers.length).toBe(0);
+		expect(room1.peers.length).toBe(0);
+		expect(room1.lobbyPeers.length).toBe(0);
 	});
 
 	it('close()', () => {
-		room.close();
-		expect(room.closed).toBe(true);
+		room1.close();
+		expect(room1.closed).toBe(true);
 		expect(spyEmit).toHaveBeenCalledTimes(1);
 	});
 
 	it('addPeer()', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
 		const spyAllowPeer = jest.spyOn(Room.prototype as any, 'allowPeer');
 
-		room.addPeer(peer);
+		room1.addPeer(peer);
 		expect(spyAllowPeer).toHaveBeenCalled();
 	});
 
 	it('allowPeer()', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		const joinMiddleware = room['joinMiddleware'];
-		const initialMediaMiddleware = room['initialMediaMiddleware'];
+		const joinMiddleware = room1['joinMiddleware'];
+		const initialMediaMiddleware = room1['initialMediaMiddleware'];
 		const spyPipeline = jest.spyOn(peer.pipeline, 'use');
 		const spyNotify = jest.spyOn(peer, 'notify');
 
-		room['allowPeer'](peer);
+		room1['allowPeer'](peer);
 
 		expect(spyAddPendingPeer).toHaveBeenCalledWith(peer);
 
@@ -89,10 +108,10 @@ describe('Room', () => {
 		expect(spyRemovePeer).not.toHaveBeenCalled();
 		expect(spyRemoveLobbyPeer).not.toHaveBeenCalled();
 
-		expect(room.pendingPeers.length).toBe(1);
-		expect(room.pendingPeers.items[0]).toBe(peer);
-		expect(room.peers.length).toBe(0);
-		expect(room.lobbyPeers.length).toBe(0);
+		expect(room1.pendingPeers.length).toBe(1);
+		expect(room1.pendingPeers.items[0]).toBe(peer);
+		expect(room1.peers.length).toBe(0);
+		expect(room1.lobbyPeers.length).toBe(0);
 
 		expect(spyPipeline).toHaveBeenCalledWith(initialMediaMiddleware, joinMiddleware);
 		expect(spyNotify).toHaveBeenCalled();
@@ -101,14 +120,14 @@ describe('Room', () => {
 	it('parkPeer()', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		const lobbyPeerMiddleware = room['lobbyPeerMiddleware'];
+		const lobbyPeerMiddleware = room1['lobbyPeerMiddleware'];
 		const spyPipeline = jest.spyOn(peer.pipeline, 'use');
 		const spyNotify = jest.spyOn(peer, 'notify');
 
-		room['parkPeer'](peer);
+		room1['parkPeer'](peer);
 		expect(spyAddLobbyPeer).toHaveBeenCalledWith(peer);
 
 		expect(spyAddPeer).not.toHaveBeenCalled();
@@ -118,10 +137,10 @@ describe('Room', () => {
 		expect(spyRemovePeer).not.toHaveBeenCalled();
 		expect(spyRemoveLobbyPeer).not.toHaveBeenCalled();
 
-		expect(room.lobbyPeers.length).toBe(1);
-		expect(room.lobbyPeers.items[0]).toBe(peer);
-		expect(room.peers.length).toBe(0);
-		expect(room.pendingPeers.length).toBe(0);
+		expect(room1.lobbyPeers.length).toBe(1);
+		expect(room1.lobbyPeers.items[0]).toBe(peer);
+		expect(room1.peers.length).toBe(0);
+		expect(room1.pendingPeers.length).toBe(0);
 
 		expect(spyPipeline).toHaveBeenCalledWith(lobbyPeerMiddleware);
 		expect(spyNotify).toHaveBeenCalled();
@@ -130,16 +149,16 @@ describe('Room', () => {
 	it('joinPeer()', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		const joinMiddleware = room['joinMiddleware'];
-		const peerMiddlewares = room['peerMiddlewares'];
+		const joinMiddleware = room1['joinMiddleware'];
+		const peerMiddlewares = room1['peerMiddlewares'];
 
 		const spyPipelineRemove = jest.spyOn(peer.pipeline, 'remove');
 		const spyPipelineUse = jest.spyOn(peer.pipeline, 'use');
 
-		room['joinPeer'](peer);
+		room1['joinPeer'](peer);
 		expect(spyAddPeer).toHaveBeenCalledWith(peer);
 		expect(spyRemovePendingPeer).toHaveBeenCalled();
 
@@ -149,10 +168,10 @@ describe('Room', () => {
 		expect(spyRemovePeer).not.toHaveBeenCalled();
 		expect(spyRemoveLobbyPeer).not.toHaveBeenCalled();
 
-		expect(room.peers.length).toBe(1);
-		expect(room.peers.items[0]).toBe(peer);
-		expect(room.lobbyPeers.length).toBe(0);
-		expect(room.pendingPeers.length).toBe(0);
+		expect(room1.peers.length).toBe(1);
+		expect(room1.peers.items[0]).toBe(peer);
+		expect(room1.lobbyPeers.length).toBe(0);
+		expect(room1.pendingPeers.length).toBe(0);
 
 		expect(spyPipelineRemove).toHaveBeenCalledWith(joinMiddleware);
 		expect(spyPipelineUse).toHaveBeenCalledWith(...peerMiddlewares);
@@ -164,15 +183,15 @@ describe('Room', () => {
 	it('promotePeer()', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		const lobbyPeerMiddleware = room['lobbyPeerMiddleware'];
+		const lobbyPeerMiddleware = room1['lobbyPeerMiddleware'];
 		const spyAllowPeer = jest.spyOn(Room.prototype as any, 'allowPeer');
 		const spyPipelineRemove = jest.spyOn(peer.pipeline, 'remove');
 
-		room['parkPeer'](peer);
-		room['promotePeer'](peer);
+		room1['parkPeer'](peer);
+		room1['promotePeer'](peer);
 
 		expect(spyRemoveLobbyPeer).toHaveBeenCalled();
 		
@@ -180,10 +199,10 @@ describe('Room', () => {
 		expect(spyRemovePeer).not.toHaveBeenCalled();
 		expect(spyRemovePendingPeer).not.toHaveBeenCalled();
 
-		expect(room.pendingPeers.length).toBe(1);
-		expect(room.pendingPeers.items[0]).toBe(peer);
-		expect(room.lobbyPeers.length).toBe(0);
-		expect(room.peers.length).toBe(0);
+		expect(room1.pendingPeers.length).toBe(1);
+		expect(room1.pendingPeers.items[0]).toBe(peer);
+		expect(room1.lobbyPeers.length).toBe(0);
+		expect(room1.peers.length).toBe(0);
 
 		expect(spyPipelineRemove).toHaveBeenCalledWith(lobbyPeerMiddleware);
 		expect(spyAllowPeer).toHaveBeenCalled();
@@ -193,186 +212,186 @@ describe('Room', () => {
 	it('removePeer() - pending peer', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room['allowPeer'](peer);
-		room.removePeer(peer);
-		expect(room.pendingPeers.length).toBe(0);
+		room1['allowPeer'](peer);
+		room1.removePeer(peer);
+		expect(room1.pendingPeers.length).toBe(0);
 	});
 
 	it('removePeer() - joined peer', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room.joinPeer(peer);
-		room.removePeer(peer);
-		expect(room.peers.length).toBe(0);
+		room1.joinPeer(peer);
+		room1.removePeer(peer);
+		expect(room1.peers.length).toBe(0);
 		expect(spyNotifyPeers).toHaveBeenCalledWith('peerClosed', { peerId: peer.id }, peer);
 	});
 
 	it('removePeer() - lobby peer', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room['parkPeer'](peer);
-		room.removePeer(peer);
-		expect(room.peers.length).toBe(0);
+		room1['parkPeer'](peer);
+		room1.removePeer(peer);
+		expect(room1.peers.length).toBe(0);
 		expect(spyNotifyPeers).toHaveBeenCalledWith('lobby:peerClosed', { peerId: peer.id }, peer);
 	});
 
 	it('removePeer() - last peer leaves', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room.joinPeer(peer);
-		room.removePeer(peer);
-		expect(room.closed).toBe(true);
+		room1.joinPeer(peer);
+		room1.removePeer(peer);
+		expect(room1.closed).toBe(true);
 	});
 
 	it('removePeer() - peer leaves, peer still there', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
 		const peer2 = new Peer({
 			id: 'test2',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room['allowPeer'](peer);
-		room['allowPeer'](peer2);
-		room.removePeer(peer);
-		expect(room.closed).toBe(false);
-		room.removePeer(peer2);
-		expect(room.closed).toBe(true);
+		room1['allowPeer'](peer);
+		room1['allowPeer'](peer2);
+		room1.removePeer(peer);
+		expect(room1.closed).toBe(false);
+		room1.removePeer(peer2);
+		expect(room1.closed).toBe(true);
 	});
 
 	it('removePeer() - peer leaves, have pending peer', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
 		const pendingPeer = new Peer({
 			id: 'test2',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room.joinPeer(pendingPeer);
-		room['allowPeer'](peer);
-		room.removePeer(peer);
-		expect(room.closed).toBe(false);
+		room1.joinPeer(pendingPeer);
+		room1['allowPeer'](peer);
+		room1.removePeer(peer);
+		expect(room1.closed).toBe(false);
 	});
 
 	it('removePeer() - peer leaves, peer in lobby', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
 		const lobbyPeer = new Peer({
 			id: 'test2',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room.joinPeer(peer);
-		room['parkPeer'](lobbyPeer);
-		room.removePeer(peer);
-		expect(room.closed).toBe(false);
+		room1.joinPeer(peer);
+		room1['parkPeer'](lobbyPeer);
+		room1.removePeer(peer);
+		expect(room1.closed).toBe(false);
 	});
 
 	it('getPeers() - joined peers', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
 		const peer2 = new Peer({
 			id: 'test2',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room.joinPeer(peer);
-		room.joinPeer(peer2);
-		expect(room.getPeers()).toEqual([ peer, peer2 ]);
+		room1.joinPeer(peer);
+		room1.joinPeer(peer2);
+		expect(room1.getPeers()).toEqual([ peer, peer2 ]);
 	});
 
 	it('getPeers() - exclude peer', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
 		const peer2 = new Peer({
 			id: 'test2',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room.joinPeer(peer);
-		room.joinPeer(peer2);
-		expect(room.getPeers(peer)).toEqual([ peer2 ]);
+		room1.joinPeer(peer);
+		room1.joinPeer(peer2);
+		expect(room1.getPeers(peer)).toEqual([ peer2 ]);
 	});
 
 	it('getPeers() - lobby peers', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
 		const peer2 = new Peer({
 			id: 'test2',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room.joinPeer(peer);
-		room['parkPeer'](peer2);
-		expect(room.getPeers()).toEqual([ peer ]);
+		room1.joinPeer(peer);
+		room1['parkPeer'](peer2);
+		expect(room1.getPeers()).toEqual([ peer ]);
 	});
 
 	it('getPeers() - pending peers', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
 		const peer2 = new Peer({
 			id: 'test2',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room.joinPeer(peer);
-		room['allowPeer'](peer2);
-		expect(room.getPeers()).toEqual([ peer ]);
+		room1.joinPeer(peer);
+		room1['allowPeer'](peer2);
+		expect(room1.getPeers()).toEqual([ peer ]);
 	});
 
 	it('notifyPeers() - all peers', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
 		const peer2 = new Peer({
 			id: 'test2',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room.joinPeer(peer);
-		room.joinPeer(peer2);
+		room1.joinPeer(peer);
+		room1.joinPeer(peer2);
 
 		const spyNotify1 = jest.spyOn(peer, 'notify');
 		const spyNotify2 = jest.spyOn(peer2, 'notify');
 
-		expect(room.peers.length).toBe(2);
+		expect(room1.peers.length).toBe(2);
 
-		room.notifyPeers('test', { test: 'test' });
+		room1.notifyPeers('test', { test: 'test' });
 
 		expect(spyNotify1).toHaveBeenCalledWith({
 			method: 'test',
@@ -387,26 +406,74 @@ describe('Room', () => {
 	it('notifyPeers() - exclude peer', () => {
 		const peer = new Peer({
 			id: 'test',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
 		const peer2 = new Peer({
 			id: 'test2',
-			roomId: roomId,
+			roomId: roomId1,
 		});
 
-		room.joinPeer(peer);
-		room.joinPeer(peer2);
+		room1.joinPeer(peer);
+		room1.joinPeer(peer2);
 
 		const spyNotify1 = jest.spyOn(peer, 'notify');
 		const spyNotify2 = jest.spyOn(peer2, 'notify');
 
-		room.notifyPeers('test', { test: 'test' }, peer);
+		room1.notifyPeers('test', { test: 'test' }, peer);
 
 		expect(spyNotify1).not.toHaveBeenCalled();
 		expect(spyNotify2).toHaveBeenCalledWith({
 			method: 'test',
 			data: { test: 'test' },
 		});
+	});
+	
+	it('addRouter() - should have one router', () => {
+		expect(room1.routers.length).toBe(0)
+		room1.addRouter(router);
+		expect(room1.routers.length).toBe(1)
+	})
+
+	describe('Multiple rooms', () => {
+	let room2: Room;
+	let room3: Room
+
+	beforeEach(() => {
+		room2 = new Room({
+			id: roomId2, 
+			mediaService: new MediaService(), 
+			name: roomName2,
+		})
+		room3 = new Room({
+			id: roomId3, 
+			mediaService: new MediaService(), 
+			name: roomName3,
+			parent: room2
+		})
+		
+	})
+
+	it('parentClosed - should return false on non-closed parent', () => {
+		expect(room3.parentClosed).toBe(false)
+	})
+
+	it('parentClosed - should return true when parent is closed', () => {
+		room2.close()
+		expect(room3.parentClosed).toBe(true)
+	})
+
+	it('addRoom() - should have one room', () => {
+		expect(room1.rooms.length).toBe(0)
+		room1.addRoom(room2);
+		expect(room1.rooms.length).toBe(1);
+		})
+	
+		it('Should remove room when it closes', () => {
+		room1.addRoom(room2)
+		expect(spyRemoveRoom).not.toHaveBeenCalled()
+		room2.close()
+		expect(spyRemoveRoom).toHaveBeenCalled()
+		})
 	});
 });

--- a/__tests__/unit-tests/Room.ts
+++ b/__tests__/unit-tests/Room.ts
@@ -3,7 +3,7 @@ import MediaService from '../../src/MediaService';
 import { Peer } from '../../src/Peer';
 import Room from '../../src/Room';
 import { Router } from '../../src/media/Router';
-import { userRoles } from '../../src/common/authorization'
+import { userRoles } from '../../src/common/authorization';
 
 describe('Room', () => {
 	let room1: Room;
@@ -24,8 +24,6 @@ describe('Room', () => {
 	const roomName2 = 'testRoomName2';
 	const roomName3 = 'testRoomName3';
 
-
-
 	beforeEach(() => {
 		room1 = new Room({
 			id: roomId1,
@@ -41,8 +39,9 @@ describe('Room', () => {
 		spyRemovePendingPeer = jest.spyOn(room1.pendingPeers, 'remove');
 		spyAddLobbyPeer = jest.spyOn(room1.lobbyPeers, 'add');
 		spyRemoveLobbyPeer = jest.spyOn(room1.lobbyPeers, 'remove');
-		spyAddRoom = jest.spyOn(room1.rooms, 'add')
-		spyRemoveRoom = jest.spyOn(room1.rooms, 'remove')
+		spyAddRoom = jest.spyOn(room1.rooms, 'add');
+
+		spyRemoveRoom = jest.spyOn(room1.rooms, 'remove');
 	});
 
 	it('Has correct properties', () => {
@@ -69,7 +68,7 @@ describe('Room', () => {
 	describe('Router', () => {
 		let router: Router;
 		let spyClose: jest.SpyInstance;
-		let spyAdd: jest.SpyInstance
+		let spyAdd: jest.SpyInstance;
 
 		beforeEach(() => {
 			router = {
@@ -79,391 +78,393 @@ describe('Room', () => {
 				rtpCapabilities: jest.fn(),
 				appData: {},
 				close: jest.fn()
-			} as unknown as Router
-			spyClose = jest.spyOn(router, 'close')
-			spyAdd = jest.spyOn(room1.routers, 'add')
-		})
+			} as unknown as Router;
+			spyClose = jest.spyOn(router, 'close');
+			spyAdd = jest.spyOn(room1.routers, 'add');
+		});
 
-	it('close() - should close router', () => {
-		room1.addRouter(router);
-		room1.close()
-		expect(spyClose).toHaveBeenCalled()
-	})
+		it('close() - should close router', () => {
+			room1.addRouter(router);
+			room1.close();
+			expect(spyClose).toHaveBeenCalled();
+		});
 
-	it('addRouter() - should have one router', () => {
-		expect(room1.routers.length).toBe(0)
-		room1.addRouter(router);
-		expect(room1.routers.length).toBe(1)
-		expect(spyAdd).toHaveBeenCalled()
-	})
+		it('addRouter() - should have one router', () => {
+			expect(room1.routers.length).toBe(0);
+			room1.addRouter(router);
+			expect(room1.routers.length).toBe(1);
+			expect(spyAdd).toHaveBeenCalled();
+		});
 
-	it('pushRouter() - should not add same router twice', () => {
-		room1.addRouter(router)
-		room1['pushRouter'](router)
-		expect(spyAdd.mock.calls.length).toBe(1)
-	})
+		it('pushRouter() - should not add same router twice', () => {
+			room1.addRouter(router);
+			room1['pushRouter'](router);
+			expect(spyAdd.mock.calls.length).toBe(1);
+		});
 
-	})
-	
-	
+	});
 
 	describe('Peers', () => {
 		let peer1: Peer;
 		let peer2: Peer;
 
 		beforeEach(() => {
-		  peer1 = new Peer({
-			id: 'test',
-			roomId: roomId1,
-		  })
-		peer2 = new Peer({
-			id: 'test2',
-			roomId: roomId1,
+			peer1 = new Peer({
+				id: 'test',
+				roomId: roomId1,
+			});
+			peer2 = new Peer({
+				id: 'test2',
+				roomId: roomId1,
 			});
 		});
 
-	it('close() - remove pending peer', () => {
-		room1.addPeer(peer1)
-		const spyClose = jest.spyOn(peer1, 'close')
-		room1.close();
-		expect(spyClose).toHaveBeenCalled()
-	})
-	
-	it('close() - remove peer', () => {
-		room1['joinPeer'](peer1)
-		const spyClose = jest.spyOn(peer1, 'close')
-		room1.close();
-		expect(spyClose).toHaveBeenCalled()
-	})
-	
-	it('close() - remove lobbyPeer', () => {
-		room1['parkPeer'](peer1)
-		const spyClose = jest.spyOn(peer1, 'close')
-		room1.close();
-		expect(spyClose).toHaveBeenCalled()
-	})
-	
-	it('addPeer()', () => {
-		const spyAllowPeer = jest.spyOn(Room.prototype as any, 'allowPeer');
-		
-		room1.addPeer(peer1);
-		
-		expect(spyAllowPeer).toHaveBeenCalled();
-	});
-	
-	it('addPeer() - room locked', () => {
-		room1.locked = true;
+		it('close() - remove pending peer', () => {
+			room1.addPeer(peer1);
+			const spyClose = jest.spyOn(peer1, 'close');
 
-		const spyParkPeer = jest.spyOn(Room.prototype as any, 'parkPeer');
-
-		room1.addPeer(peer1);
-		expect(spyParkPeer).toHaveBeenCalled();
-	});
-	
-	it('addPeer() - room locked, promote peer to admin', () => {
-		room1.locked = true;
-
-		const spyPromotePeer = jest.spyOn(Room.prototype as any, 'promotePeer');
-		room1.addPeer(peer1);
-		peer1.addRole(userRoles.ADMIN)
-		
-		expect(spyPromotePeer).toHaveBeenCalled();
-	});
-
-	it('allowPeer()', () => {
-
-		const joinMiddleware = room1['joinMiddleware'];
-		const initialMediaMiddleware = room1['initialMediaMiddleware'];
-		const spyPipeline = jest.spyOn(peer1.pipeline, 'use');
-		const spyNotify = jest.spyOn(peer1, 'notify');
-
-		room1['allowPeer'](peer1);
-
-		expect(spyAddPendingPeer).toHaveBeenCalledWith(peer1);
-
-		expect(spyAddPeer).not.toHaveBeenCalled();
-		expect(spyAddLobbyPeer).not.toHaveBeenCalled();
-
-		expect(spyRemovePendingPeer).not.toHaveBeenCalled();
-		expect(spyRemovePeer).not.toHaveBeenCalled();
-		expect(spyRemoveLobbyPeer).not.toHaveBeenCalled();
-
-		expect(room1.pendingPeers.length).toBe(1);
-		expect(room1.pendingPeers.items[0]).toBe(peer1);
-		expect(room1.peers.length).toBe(0);
-		expect(room1.lobbyPeers.length).toBe(0);
-
-		expect(spyPipeline).toHaveBeenCalledWith(initialMediaMiddleware, joinMiddleware);
-		expect(spyNotify).toHaveBeenCalled();
-	});
-
-	it('parkPeer()', () => {
-		const lobbyPeerMiddleware = room1['lobbyPeerMiddleware'];
-		const spyPipeline = jest.spyOn(peer1.pipeline, 'use');
-		const spyNotify = jest.spyOn(peer1, 'notify');
-
-		room1['parkPeer'](peer1);
-		expect(spyAddLobbyPeer).toHaveBeenCalledWith(peer1);
-
-		expect(spyAddPeer).not.toHaveBeenCalled();
-		expect(spyAddPendingPeer).not.toHaveBeenCalled();
-
-		expect(spyRemovePendingPeer).not.toHaveBeenCalled();
-		expect(spyRemovePeer).not.toHaveBeenCalled();
-		expect(spyRemoveLobbyPeer).not.toHaveBeenCalled();
-
-		expect(room1.lobbyPeers.length).toBe(1);
-		expect(room1.lobbyPeers.items[0]).toBe(peer1);
-		expect(room1.peers.length).toBe(0);
-		expect(room1.pendingPeers.length).toBe(0);
-
-		expect(spyPipeline).toHaveBeenCalledWith(lobbyPeerMiddleware);
-		expect(spyNotify).toHaveBeenCalled();
-	});
-
-	it('joinPeer()', () => {
-		const joinMiddleware = room1['joinMiddleware'];
-		const peerMiddlewares = room1['peerMiddlewares'];
-
-		const spyPipelineRemove = jest.spyOn(peer1.pipeline, 'remove');
-		const spyPipelineUse = jest.spyOn(peer1.pipeline, 'use');
-
-		room1['joinPeer'](peer1);
-		expect(spyAddPeer).toHaveBeenCalledWith(peer1);
-		expect(spyRemovePendingPeer).toHaveBeenCalled();
-
-		expect(spyAddLobbyPeer).not.toHaveBeenCalled();
-		expect(spyAddPendingPeer).not.toHaveBeenCalled();
-
-		expect(spyRemovePeer).not.toHaveBeenCalled();
-		expect(spyRemoveLobbyPeer).not.toHaveBeenCalled();
-
-		expect(room1.peers.length).toBe(1);
-		expect(room1.peers.items[0]).toBe(peer1);
-		expect(room1.lobbyPeers.length).toBe(0);
-		expect(room1.pendingPeers.length).toBe(0);
-
-		expect(spyPipelineRemove).toHaveBeenCalledWith(joinMiddleware);
-		expect(spyPipelineUse).toHaveBeenCalledWith(...peerMiddlewares);
-		expect(spyNotifyPeers).toHaveBeenCalledWith('newPeer', {
-			...peer1.peerInfo
-		}, peer1);
-	});
-
-	it('promotePeer()', () => {
-		const lobbyPeerMiddleware = room1['lobbyPeerMiddleware'];
-		const spyAllowPeer = jest.spyOn(Room.prototype as any, 'allowPeer');
-		const spyPipelineRemove = jest.spyOn(peer1.pipeline, 'remove');
-
-		room1['parkPeer'](peer1);
-		room1['promotePeer'](peer1);
-
-		expect(spyRemoveLobbyPeer).toHaveBeenCalled();
-		
-		expect(spyAddPeer).not.toHaveBeenCalled();
-		expect(spyRemovePeer).not.toHaveBeenCalled();
-		expect(spyRemovePendingPeer).not.toHaveBeenCalled();
-
-		expect(room1.pendingPeers.length).toBe(1);
-		expect(room1.pendingPeers.items[0]).toBe(peer1);
-		expect(room1.lobbyPeers.length).toBe(0);
-		expect(room1.peers.length).toBe(0);
-
-		expect(spyPipelineRemove).toHaveBeenCalledWith(lobbyPeerMiddleware);
-		expect(spyAllowPeer).toHaveBeenCalled();
-		expect(spyNotifyPeers).toHaveBeenCalledWith('lobby:promotedPeer', { peerId: peer1.id }, peer1);
-	});
-
-	it('promoteAllPeers()', () => {
-		room1['parkPeer'](peer1)
-		room1.joinPeer(peer2)
-		
-		expect(room1.lobbyPeers.length).toBe(1)
-		expect(room1.peers.length).toBe(1)
-		room1.promoteAllPeers()
-
-		expect(room1.pendingPeers.length).toBe(1)
-	})
-
-	it('removePeer() - pending peer', () => {
-		room1['allowPeer'](peer1);
-		room1.removePeer(peer1);
-		expect(room1.pendingPeers.length).toBe(0);
-	});
-
-	it('removePeer() - joined peer', () => {
-		room1.joinPeer(peer1);
-		room1.removePeer(peer1);
-		expect(room1.peers.length).toBe(0);
-		expect(spyNotifyPeers).toHaveBeenCalledWith('peerClosed', { peerId: peer1.id }, peer1);
-	});
-
-	it('removePeer() - lobby peer', () => {
-		room1['parkPeer'](peer1);
-		room1.removePeer(peer1);
-		expect(room1.peers.length).toBe(0);
-		expect(spyNotifyPeers).toHaveBeenCalledWith('lobby:peerClosed', { peerId: peer1.id }, peer1);
-	});
-
-	it('removePeer() - last peer leaves', () => {
-		room1.joinPeer(peer1);
-		room1.removePeer(peer1);
-		expect(room1.closed).toBe(true);
-	});
-
-	it('removePeer() - peer leaves, peer still there', () => {
-
-		room1['allowPeer'](peer1);
-		room1['allowPeer'](peer2);
-		room1.removePeer(peer1);
-		expect(room1.closed).toBe(false);
-		room1.removePeer(peer2);
-		expect(room1.closed).toBe(true);
-	});
-
-	it('removePeer() - peer leaves, have pending peer', () => {
-		const pendingPeer = new Peer({
-			id: 'test2',
-			roomId: roomId1,
+			room1.close();
+			expect(spyClose).toHaveBeenCalled();
 		});
 
-		room1.joinPeer(pendingPeer);
-		room1['allowPeer'](peer1);
-		room1.removePeer(peer1);
-		expect(room1.closed).toBe(false);
-	});
+		it('close() - remove peer', () => {
+			room1['joinPeer'](peer1);
+			const spyClose = jest.spyOn(peer1, 'close');
 
-	it('removePeer() - peer leaves, peer in lobby', () => {
-		const lobbyPeer = new Peer({
-			id: 'test2',
-			roomId: roomId1,
+			room1.close();
+			expect(spyClose).toHaveBeenCalled();
 		});
 
-		room1.joinPeer(peer1);
-		room1['parkPeer'](lobbyPeer);
-		room1.removePeer(peer1);
-		expect(room1.closed).toBe(false);
-	});
-	
-	it('removePeer() - peer leaves, peer in lobby', () => {
-		const lobbyPeer = new Peer({
-			id: 'test2',
-			roomId: roomId1,
+		it('close() - remove lobbyPeer', () => {
+			room1['parkPeer'](peer1);
+			const spyClose = jest.spyOn(peer1, 'close');
+
+			room1.close();
+			expect(spyClose).toHaveBeenCalled();
 		});
 
-		room1.joinPeer(peer1);
-		room1['parkPeer'](lobbyPeer);
-		room1.removePeer(peer1);
-		expect(room1.closed).toBe(false);
-	});
+		it('addPeer()', () => {
+			const spyAllowPeer = jest.spyOn(Room.prototype as any, 'allowPeer');
 
-	it('getPeers() - joined peers', () => {
-		const peer2 = new Peer({
-			id: 'test2',
-			roomId: roomId1,
+			room1.addPeer(peer1);
+
+			expect(spyAllowPeer).toHaveBeenCalled();
 		});
 
-		room1.joinPeer(peer1);
-		room1.joinPeer(peer2);
-		expect(room1.getPeers()).toEqual([ peer1, peer2 ]);
-	});
+		it('addPeer() - room locked', () => {
+			room1.locked = true;
 
-	it('getPeers() - exclude peer', () => {
+			const spyParkPeer = jest.spyOn(Room.prototype as any, 'parkPeer');
 
-		room1.joinPeer(peer1);
-		room1.joinPeer(peer2);
-		expect(room1.getPeers(peer1)).toEqual([ peer2 ]);
-	});
-
-	it('getPeers() - lobby peers', () => {
-		room1.joinPeer(peer1);
-		room1['parkPeer'](peer2);
-		expect(room1.getPeers()).toEqual([ peer1 ]);
-	});
-
-	it('getPeers() - pending peers', () => {
-		room1.joinPeer(peer1);
-		room1['allowPeer'](peer2);
-		expect(room1.getPeers()).toEqual([ peer1 ]);
-	});
-	
-	it('notifyPeers() - all peers', () => {
-		room1.joinPeer(peer1);
-		room1.joinPeer(peer2);
-
-		const spyNotify1 = jest.spyOn(peer1, 'notify');
-		const spyNotify2 = jest.spyOn(peer2, 'notify');
-
-		expect(room1.peers.length).toBe(2);
-
-		room1.notifyPeers('test', { test: 'test' });
-
-		expect(spyNotify1).toHaveBeenCalledWith({
-			method: 'test',
-			data: { test: 'test' },
+			room1.addPeer(peer1);
+			expect(spyParkPeer).toHaveBeenCalled();
 		});
-		expect(spyNotify2).toHaveBeenCalledWith({
-			method: 'test',
-			data: { test: 'test' },
+
+		it('addPeer() - room locked, promote peer to admin', () => {
+			room1.locked = true;
+
+			const spyPromotePeer = jest.spyOn(Room.prototype as any, 'promotePeer');
+
+			room1.addPeer(peer1);
+			peer1.addRole(userRoles.ADMIN);
+
+			expect(spyPromotePeer).toHaveBeenCalled();
+		});
+
+		it('allowPeer()', () => {
+
+			const joinMiddleware = room1['joinMiddleware'];
+			const initialMediaMiddleware = room1['initialMediaMiddleware'];
+			const spyPipeline = jest.spyOn(peer1.pipeline, 'use');
+			const spyNotify = jest.spyOn(peer1, 'notify');
+
+			room1['allowPeer'](peer1);
+
+			expect(spyAddPendingPeer).toHaveBeenCalledWith(peer1);
+
+			expect(spyAddPeer).not.toHaveBeenCalled();
+			expect(spyAddLobbyPeer).not.toHaveBeenCalled();
+
+			expect(spyRemovePendingPeer).not.toHaveBeenCalled();
+			expect(spyRemovePeer).not.toHaveBeenCalled();
+			expect(spyRemoveLobbyPeer).not.toHaveBeenCalled();
+
+			expect(room1.pendingPeers.length).toBe(1);
+			expect(room1.pendingPeers.items[0]).toBe(peer1);
+			expect(room1.peers.length).toBe(0);
+			expect(room1.lobbyPeers.length).toBe(0);
+
+			expect(spyPipeline).toHaveBeenCalledWith(initialMediaMiddleware, joinMiddleware);
+			expect(spyNotify).toHaveBeenCalled();
+		});
+
+		it('parkPeer()', () => {
+			const lobbyPeerMiddleware = room1['lobbyPeerMiddleware'];
+			const spyPipeline = jest.spyOn(peer1.pipeline, 'use');
+			const spyNotify = jest.spyOn(peer1, 'notify');
+
+			room1['parkPeer'](peer1);
+			expect(spyAddLobbyPeer).toHaveBeenCalledWith(peer1);
+
+			expect(spyAddPeer).not.toHaveBeenCalled();
+			expect(spyAddPendingPeer).not.toHaveBeenCalled();
+
+			expect(spyRemovePendingPeer).not.toHaveBeenCalled();
+			expect(spyRemovePeer).not.toHaveBeenCalled();
+			expect(spyRemoveLobbyPeer).not.toHaveBeenCalled();
+
+			expect(room1.lobbyPeers.length).toBe(1);
+			expect(room1.lobbyPeers.items[0]).toBe(peer1);
+			expect(room1.peers.length).toBe(0);
+			expect(room1.pendingPeers.length).toBe(0);
+
+			expect(spyPipeline).toHaveBeenCalledWith(lobbyPeerMiddleware);
+			expect(spyNotify).toHaveBeenCalled();
+		});
+
+		it('joinPeer()', () => {
+			const joinMiddleware = room1['joinMiddleware'];
+			const peerMiddlewares = room1['peerMiddlewares'];
+
+			const spyPipelineRemove = jest.spyOn(peer1.pipeline, 'remove');
+			const spyPipelineUse = jest.spyOn(peer1.pipeline, 'use');
+
+			room1['joinPeer'](peer1);
+			expect(spyAddPeer).toHaveBeenCalledWith(peer1);
+			expect(spyRemovePendingPeer).toHaveBeenCalled();
+
+			expect(spyAddLobbyPeer).not.toHaveBeenCalled();
+			expect(spyAddPendingPeer).not.toHaveBeenCalled();
+
+			expect(spyRemovePeer).not.toHaveBeenCalled();
+			expect(spyRemoveLobbyPeer).not.toHaveBeenCalled();
+
+			expect(room1.peers.length).toBe(1);
+			expect(room1.peers.items[0]).toBe(peer1);
+			expect(room1.lobbyPeers.length).toBe(0);
+			expect(room1.pendingPeers.length).toBe(0);
+
+			expect(spyPipelineRemove).toHaveBeenCalledWith(joinMiddleware);
+			expect(spyPipelineUse).toHaveBeenCalledWith(...peerMiddlewares);
+			expect(spyNotifyPeers).toHaveBeenCalledWith('newPeer', {
+				...peer1.peerInfo
+			}, peer1);
+		});
+
+		it('promotePeer()', () => {
+			const lobbyPeerMiddleware = room1['lobbyPeerMiddleware'];
+			const spyAllowPeer = jest.spyOn(Room.prototype as any, 'allowPeer');
+			const spyPipelineRemove = jest.spyOn(peer1.pipeline, 'remove');
+
+			room1['parkPeer'](peer1);
+			room1['promotePeer'](peer1);
+
+			expect(spyRemoveLobbyPeer).toHaveBeenCalled();
+
+			expect(spyAddPeer).not.toHaveBeenCalled();
+			expect(spyRemovePeer).not.toHaveBeenCalled();
+			expect(spyRemovePendingPeer).not.toHaveBeenCalled();
+
+			expect(room1.pendingPeers.length).toBe(1);
+			expect(room1.pendingPeers.items[0]).toBe(peer1);
+			expect(room1.lobbyPeers.length).toBe(0);
+			expect(room1.peers.length).toBe(0);
+
+			expect(spyPipelineRemove).toHaveBeenCalledWith(lobbyPeerMiddleware);
+			expect(spyAllowPeer).toHaveBeenCalled();
+			expect(spyNotifyPeers).toHaveBeenCalledWith('lobby:promotedPeer', { peerId: peer1.id }, peer1);
+		});
+
+		it('promoteAllPeers()', () => {
+			room1['parkPeer'](peer1);
+			room1.joinPeer(peer2);
+
+			expect(room1.lobbyPeers.length).toBe(1);
+			expect(room1.peers.length).toBe(1);
+			room1.promoteAllPeers();
+
+			expect(room1.pendingPeers.length).toBe(1);
+		});
+
+		it('removePeer() - pending peer', () => {
+			room1['allowPeer'](peer1);
+			room1.removePeer(peer1);
+			expect(room1.pendingPeers.length).toBe(0);
+		});
+
+		it('removePeer() - joined peer', () => {
+			room1.joinPeer(peer1);
+			room1.removePeer(peer1);
+			expect(room1.peers.length).toBe(0);
+			expect(spyNotifyPeers).toHaveBeenCalledWith('peerClosed', { peerId: peer1.id }, peer1);
+		});
+
+		it('removePeer() - lobby peer', () => {
+			room1['parkPeer'](peer1);
+			room1.removePeer(peer1);
+			expect(room1.peers.length).toBe(0);
+			expect(spyNotifyPeers).toHaveBeenCalledWith('lobby:peerClosed', { peerId: peer1.id }, peer1);
+		});
+
+		it('removePeer() - last peer leaves', () => {
+			room1.joinPeer(peer1);
+			room1.removePeer(peer1);
+			expect(room1.closed).toBe(true);
+		});
+
+		it('removePeer() - peer leaves, peer still there', () => {
+
+			room1['allowPeer'](peer1);
+			room1['allowPeer'](peer2);
+			room1.removePeer(peer1);
+			expect(room1.closed).toBe(false);
+			room1.removePeer(peer2);
+			expect(room1.closed).toBe(true);
+		});
+
+		it('removePeer() - peer leaves, have pending peer', () => {
+			const pendingPeer = new Peer({
+				id: 'test2',
+				roomId: roomId1,
+			});
+
+			room1.joinPeer(pendingPeer);
+			room1['allowPeer'](peer1);
+			room1.removePeer(peer1);
+			expect(room1.closed).toBe(false);
+		});
+
+		it('removePeer() - peer leaves, peer in lobby', () => {
+			const lobbyPeer = new Peer({
+				id: 'test2',
+				roomId: roomId1,
+			});
+
+			room1.joinPeer(peer1);
+			room1['parkPeer'](lobbyPeer);
+			room1.removePeer(peer1);
+			expect(room1.closed).toBe(false);
+		});
+
+		it('removePeer() - peer leaves, peer in lobby', () => {
+			const lobbyPeer = new Peer({
+				id: 'test2',
+				roomId: roomId1,
+			});
+
+			room1.joinPeer(peer1);
+			room1['parkPeer'](lobbyPeer);
+			room1.removePeer(peer1);
+			expect(room1.closed).toBe(false);
+		});
+
+		it('getPeers() - joined peers', () => {
+			const peer2 = new Peer({
+				id: 'test2',
+				roomId: roomId1,
+			});
+
+			room1.joinPeer(peer1);
+			room1.joinPeer(peer2);
+			expect(room1.getPeers()).toEqual([ peer1, peer2 ]);
+		});
+
+		it('getPeers() - exclude peer', () => {
+
+			room1.joinPeer(peer1);
+			room1.joinPeer(peer2);
+			expect(room1.getPeers(peer1)).toEqual([ peer2 ]);
+		});
+
+		it('getPeers() - lobby peers', () => {
+			room1.joinPeer(peer1);
+			room1['parkPeer'](peer2);
+			expect(room1.getPeers()).toEqual([ peer1 ]);
+		});
+
+		it('getPeers() - pending peers', () => {
+			room1.joinPeer(peer1);
+			room1['allowPeer'](peer2);
+			expect(room1.getPeers()).toEqual([ peer1 ]);
+		});
+
+		it('notifyPeers() - all peers', () => {
+			room1.joinPeer(peer1);
+			room1.joinPeer(peer2);
+
+			const spyNotify1 = jest.spyOn(peer1, 'notify');
+			const spyNotify2 = jest.spyOn(peer2, 'notify');
+
+			expect(room1.peers.length).toBe(2);
+
+			room1.notifyPeers('test', { test: 'test' });
+
+			expect(spyNotify1).toHaveBeenCalledWith({
+				method: 'test',
+				data: { test: 'test' },
+			});
+			expect(spyNotify2).toHaveBeenCalledWith({
+				method: 'test',
+				data: { test: 'test' },
+			});
+		});
+
+		it('notifyPeers() - exclude peer', () => {
+			room1.joinPeer(peer1);
+			room1.joinPeer(peer2);
+
+			const spyNotify1 = jest.spyOn(peer1, 'notify');
+			const spyNotify2 = jest.spyOn(peer2, 'notify');
+
+			room1.notifyPeers('test', { test: 'test' }, peer1);
+
+			expect(spyNotify1).not.toHaveBeenCalled();
+			expect(spyNotify2).toHaveBeenCalledWith({
+				method: 'test',
+				data: { test: 'test' },
+			});
 		});
 	});
-
-	it('notifyPeers() - exclude peer', () => {
-		room1.joinPeer(peer1);
-		room1.joinPeer(peer2);
-
-		const spyNotify1 = jest.spyOn(peer1, 'notify');
-		const spyNotify2 = jest.spyOn(peer2, 'notify');
-
-		room1.notifyPeers('test', { test: 'test' }, peer1);
-
-		expect(spyNotify1).not.toHaveBeenCalled();
-		expect(spyNotify2).toHaveBeenCalledWith({
-			method: 'test',
-			data: { test: 'test' },
-		});
-	});
-	})
 
 	describe('Multiple rooms', () => {
-	let room2: Room;
-	let room3: Room
+		let room2: Room;
+		let room3: Room;
 
-	beforeEach(() => {
-		room2 = new Room({
-			id: roomId2, 
-			mediaService: new MediaService(), 
-			name: roomName2,
-		})
-		room3 = new Room({
-			id: roomId3, 
-			mediaService: new MediaService(), 
-			name: roomName3,
-			parent: room2
-		})
-		
-	})
+		beforeEach(() => {
+			room2 = new Room({
+				id: roomId2,
+				mediaService: new MediaService(),
+				name: roomName2,
+			});
+			room3 = new Room({
+				id: roomId3,
+				mediaService: new MediaService(),
+				name: roomName3,
+				parent: room2
+			});
 
-	it('parentClosed - should return false on non-closed parent', () => {
-		expect(room3.parentClosed).toBe(false)
-	})
+		});
 
-	it('parentClosed - should return true when parent is closed', () => {
-		room2.close()
-		expect(room3.parentClosed).toBe(true)
-	})
+		it('parentClosed - should return false on non-closed parent', () => {
+			expect(room3.parentClosed).toBe(false);
+		});
 
-	it('addRoom() - should have one room', () => {
-		expect(room1.rooms.length).toBe(0)
-		room1.addRoom(room2);
-		expect(room1.rooms.length).toBe(1);
-		})
-	
-	it('close() - Parent Should remove child room when it calls close()', () => {
-		room1.addRoom(room2)
-		room2.close()
+		it('parentClosed - should return true when parent is closed', () => {
+			room2.close();
+			expect(room3.parentClosed).toBe(true);
+		});
 
-		expect(spyRemoveRoom).toHaveBeenCalled()
-		})
+		it('addRoom() - should have one room', () => {
+			expect(room1.rooms.length).toBe(0);
+			room1.addRoom(room2);
+			expect(room1.rooms.length).toBe(1);
+		});
+
+		it('close() - Parent Should remove child room when it calls close()', () => {
+			room1.addRoom(room2);
+			room2.close();
+
+			expect(spyRemoveRoom).toHaveBeenCalled();
+		});
 	});
 });

--- a/__tests__/unit-tests/ServerManager.ts
+++ b/__tests__/unit-tests/ServerManager.ts
@@ -129,8 +129,15 @@ describe('ServerManager', () => {
 			expect(serverManager.rooms.get(roomId1)).toBeDefined();
 			expect(serverManager.peers.get(peerId1)).toBeDefined();
 			expect(serverManager.peers.get(peerId1)?.roomId).toBe(roomId1);
-		});
-
+		});-
+		
+		it('should close peer connections when closing servermanager', () => {
+      		const peer1 = serverManager.peers.get(peerId1)!;
+      		const spyClose: jest.SpyInstance = jest.spyOn(peer1, "close");
+      		serverManager.close();
+      		expect(spyClose).toHaveBeenCalled();
+    	});
+		
 		describe('second peer', () => {
 			beforeEach(() => {
 				// Second client joins, should end up with two peers in one room

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"lint": "eslint . --ext .ts",
 		"connect": "node connect.js",
 		"test": "jest",
-		"test:coverage": "jest --coverage",
+		"test:coverage": "jest --coverage --coverageDirectory coverage",
 		"test:watch": "jest --watch"
 	},
 	"devDependencies": {


### PR DESCRIPTION
This PR will add unit-tests for `Room`,` Peer`, `MediaService` and `ServerManager` classes.
Also some refactoring of existing tests for these classes.

It also add VSCode workspace files to `.gitignore`.
Finally it changes the `test:coverage` script to output coverage to `coverage/` folder