### PR TITLE
Enable lint for tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
-/__tests__/**/*
 connect.js

--- a/__tests__/unit-tests/PipeTransport.ts
+++ b/__tests__/unit-tests/PipeTransport.ts
@@ -66,17 +66,18 @@ describe('PipeTransport', () => {
 
 		pipeTransport.connection.notify = jest.fn(({ method, data }) => {
 			return ({
-				'closePipeTransport': ()=> {
+				'closePipeTransport': () => {
 					expect(data.routerId).toBe(pipeTransport.router.id);
 					expect(data.pipeTransportId).toBe(pipeTransportId);
 				},
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		pipeTransport.close();
 		expect(pipeTransport.connection.notify).toBeCalledTimes(1);
 		expect(pipeTransport.closed).toBe(true);
-		expect(pipeTransport.connection.pipeline.remove).toHaveBeenCalledWith(pipeTransportMiddleware);
+		expect(pipeTransport.connection.pipeline.remove).
+			toHaveBeenCalledWith(pipeTransportMiddleware);
 	});
 
 	it('connect()', async () => {
@@ -89,7 +90,7 @@ describe('PipeTransport', () => {
 					expect(data.port).toBe(port);
 					expect(data.srtpParameters).toBe(srtpParameters);
 				}
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		await pipeTransport.connect({ ip, port, srtpParameters });
@@ -112,7 +113,7 @@ describe('PipeTransport', () => {
 
 					return { id: producerId };
 				}
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		const pipeProducer = await pipeTransport.produce({
@@ -146,7 +147,7 @@ describe('PipeTransport', () => {
 						rtpParameters,
 					};
 				}
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		const pipeConsumer = await pipeTransport.consume({

--- a/__tests__/unit-tests/Room.ts
+++ b/__tests__/unit-tests/Room.ts
@@ -1,7 +1,6 @@
-import { Pipeline } from 'edumeet-common';
 import 'jest';
 import MediaService from '../../src/MediaService';
-import { Peer, PeerContext } from '../../src/Peer';
+import { Peer } from '../../src/Peer';
 import Room from '../../src/Room';
 
 describe('Room', () => {
@@ -61,6 +60,7 @@ describe('Room', () => {
 			roomId: roomId,
 		});
 
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const spyAllowPeer = jest.spyOn(Room.prototype as any, 'allowPeer');
 
 		room.addPeer(peer);
@@ -168,6 +168,7 @@ describe('Room', () => {
 		});
 
 		const lobbyPeerMiddleware = room['lobbyPeerMiddleware'];
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const spyAllowPeer = jest.spyOn(Room.prototype as any, 'allowPeer');
 		const spyPipelineRemove = jest.spyOn(peer.pipeline, 'remove');
 

--- a/__tests__/unit-tests/Router.ts
+++ b/__tests__/unit-tests/Router.ts
@@ -110,24 +110,24 @@ describe('Router', () => {
 	it('canConsume()', async () => {
 		const producerId = 'testProducerId';
 		const rtpCapabilities = {
-			codecs: [{
+			codecs: [ {
 				kind: 'audio',
 				mimeType: 'audio/opus',
 				clockRate: 48000,
 				channels: 2,
-			}],
+			} ],
 		} as RtpCapabilities;
 
 		router1.connection.request = jest.fn(async ({ method, data }) => {
 			return ({
-				'canConsume': ()=> {
+				'canConsume': () => {
 					expect(data.routerId).toBe(router1.id);
 					expect(data.producerId).toBe(producerId);
 					expect(data.rtpCapabilities).toBe(rtpCapabilities);
 
 					return { canConsume: true };
 				},
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		const canConsume = await router1.canConsume({
@@ -144,7 +144,7 @@ describe('Router', () => {
 
 		router1.connection.request = jest.fn(async ({ method, data }) => {
 			return ({
-				'createWebRtcTransport': ()=> {
+				'createWebRtcTransport': () => {
 					expect(data.routerId).toBe(router1.id);
 					expect(data.forceTcp).toBe(false);
 					expect(data.sctpCapabilities).toBe(sctpCapabilities);
@@ -157,7 +157,7 @@ describe('Router', () => {
 						sctpParameters: {},
 					};
 				},
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		const transport = await router1.createWebRtcTransport({
@@ -174,7 +174,7 @@ describe('Router', () => {
 
 		router1.connection.request = jest.fn(async ({ method, data }) => {
 			return ({
-				'createPipeTransport': ()=> {
+				'createPipeTransport': () => {
 					expect(data.routerId).toBe(router1.id);
 					expect(data.internal).toBe(false);
 
@@ -185,7 +185,7 @@ describe('Router', () => {
 						srtpParameters: {},
 					};
 				},
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		const transport = await router1.createPipeTransport({
@@ -237,7 +237,7 @@ describe('Router', () => {
 						rtpParameters,
 					};
 				}
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		router2.connection.request = jest.fn(async ({ method, data }) => {
@@ -270,7 +270,7 @@ describe('Router', () => {
 
 					return { id: producerId };
 				}
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		const producer = new Producer({
@@ -283,7 +283,7 @@ describe('Router', () => {
 		});
 
 		try {
-			const { pipeProducer, pipeConsumer } = await router1.pipeToRouter({
+			await router1.pipeToRouter({
 				producerId,
 				router: router2,
 			});
@@ -351,7 +351,7 @@ describe('Router', () => {
 						rtpParameters,
 					};
 				}
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		router3.connection.request = jest.fn(async ({ method, data }) => {
@@ -384,7 +384,7 @@ describe('Router', () => {
 
 					return { id: producerId };
 				}
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		const producer = new Producer({
@@ -397,7 +397,7 @@ describe('Router', () => {
 		});
 
 		try {
-			const { pipeProducer, pipeConsumer } = await router1.pipeToRouter({
+			await router1.pipeToRouter({
 				producerId,
 				router: router3,
 			});

--- a/__tests__/unit-tests/ServerManager.ts
+++ b/__tests__/unit-tests/ServerManager.ts
@@ -155,14 +155,19 @@ describe('ServerManager', () => {
 			expect(serverManager.rooms.get(roomId1)).toBeDefined();
 			expect(serverManager.peers.get(peerId1)).toBeDefined();
 			expect(serverManager.peers.get(peerId1)?.roomId).toBe(roomId1);
-		});-
+		}); 
 		
 		it('should close peer connections when closing servermanager', () => {
-      		const peer1 = serverManager.peers.get(peerId1)!;
-      		const spyClose: jest.SpyInstance = jest.spyOn(peer1, "close");
-      		serverManager.close();
-      		expect(spyClose).toHaveBeenCalled();
-    	});
+			const peer1 = serverManager.peers.get(peerId1);
+
+			expect(peer1).toBeTruthy();
+			if (peer1) {
+				const spyClose: jest.SpyInstance = jest.spyOn(peer1, 'close');
+
+				serverManager.close();
+				expect(spyClose).toHaveBeenCalled();
+			}
+		});
 		
 		describe('second peer', () => {
 			beforeEach(() => {

--- a/__tests__/unit-tests/ServerManager.ts
+++ b/__tests__/unit-tests/ServerManager.ts
@@ -36,6 +36,7 @@ describe('ServerManager', () => {
 		expect(serverManager.rooms.size).toBe(0);
 
 		const spy = jest.spyOn(serverManager.mediaService, 'close');
+
 		serverManager.close();
 		expect(spy).not.toHaveBeenCalled();
 	});
@@ -83,10 +84,21 @@ describe('ServerManager', () => {
 		});
 
 		it('first peer tries to join different room', () => {
-			const peer = serverManager.peers.get(peerId1)!;
+			const peer = serverManager.peers.get(peerId1);
+
+			if (!peer) {
+				throw new Error('Peer was undefined');
+			}
+
 			const peerToken = peer.token;
 
-			serverManager.handleConnection(connection1, peerId1, roomId2, displayName, peerToken);
+			serverManager.handleConnection(
+				connection1, 
+				peerId1, 
+				roomId2, 
+				displayName, 
+				peerToken
+			);
 			expect(serverManager.peers.size).toBe(1);
 			expect(serverManager.rooms.size).toBe(1);
 			expect(serverManager.rooms.get(roomId1)).toBeUndefined();
@@ -114,14 +126,28 @@ describe('ServerManager', () => {
 		});
 
 		it('peer with valid token', () => {
-			const peer = serverManager.peers.get(peerId1)!;
+			const peer = serverManager.peers.get(peerId1);
+
+			if (!peer) {
+				throw new Error('Peer was undefined');
+			}
 			const spyClose: jest.SpyInstance = jest.spyOn(peer, 'close');
+
 			spyConnectionClose = jest.spyOn(connection1, 'close');
 			const peerToken = peer.token;
 	
-			// Try to join with a second peer with the same peerId and correct token should work,
-			// and should end up with one peer in one room still
-			serverManager.handleConnection(connection1, peerId1, roomId1, displayName, peerToken);
+			/**
+			 * Try to join with a second peer
+			 * Same peerId and correct token should work
+			 * Should end up with one peer in one room
+			 */
+			serverManager.handleConnection(
+				connection1, 
+				peerId1, 
+				roomId1, 
+				displayName, 
+				peerToken
+			);
 			expect(spyClose).toHaveBeenCalled();
 			expect(spyConnectionClose).toHaveBeenCalled();
 			expect(serverManager.peers.size).toBe(1);
@@ -138,8 +164,11 @@ describe('ServerManager', () => {
 			});
 
 			it('second peer joins', () => {
-				// Try to join with a second peer with a different peerId and no token should work,
-				// and should end up with two peers in one room
+				/**
+				 * Try to join with a second peer
+				 * A different peerId and no token should work
+				 * Should end up with two peers in one room
+				 */
 				expect(serverManager.peers.size).toBe(2);
 				expect(serverManager.rooms.size).toBe(1);
 				expect(serverManager.rooms.get(roomId1)).toBeDefined();
@@ -157,11 +186,18 @@ describe('ServerManager', () => {
 				expect(serverManager.peers.get(peerId3)).toBeDefined();
 				expect(serverManager.peers.get(peerId3)?.roomId).toBe(roomId2);
 		
-				const peer1 = serverManager.peers.get(peerId1)!;
-				const peer2 = serverManager.peers.get(peerId2)!;
-				const peer3 = serverManager.peers.get(peerId3)!;
+				const peer1 = serverManager.peers.get(peerId1);
+				const peer2 = serverManager.peers.get(peerId2);
+				const peer3 = serverManager.peers.get(peerId3);
+				
+				if (!peer1 || !peer2 || !peer3) {
+					throw new Error('Peer was undefined');
+				}
 		
-				// One of the peers in the first room leaves, should end up with two peers in two rooms
+				/**
+				 * One of the peers in the first room leaves
+				 * Should end up with two peers in two rooms
+				 */
 				peer1.close();
 		
 				expect(serverManager.peers.size).toBe(2);

--- a/__tests__/unit-tests/WebRtcTransport.ts
+++ b/__tests__/unit-tests/WebRtcTransport.ts
@@ -70,17 +70,18 @@ describe('WebRtcTransport', () => {
 
 		webRtcTransport.connection.notify = jest.fn(({ method, data }) => {
 			return ({
-				'closeWebRtcTransport': ()=> {
+				'closeWebRtcTransport': () => {
 					expect(data.routerId).toBe(webRtcTransport.router.id);
 					expect(data.transportId).toBe(transportId);
 				},
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		webRtcTransport.close();
 		expect(webRtcTransport.connection.notify).toBeCalledTimes(1);
 		expect(webRtcTransport.closed).toBe(true);
-		expect(webRtcTransport.connection.pipeline.remove).toHaveBeenCalledWith(webRtcTransportMiddleware);
+		expect(webRtcTransport.connection.pipeline.remove).
+			toHaveBeenCalledWith(webRtcTransportMiddleware);
 	});
 
 	it('connect()', async () => {
@@ -91,7 +92,7 @@ describe('WebRtcTransport', () => {
 					expect(data.transportId).toBe(transportId);
 					expect(data.dtlsParameters).toBe(dtlsParameters);
 				}
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		await webRtcTransport.connect({ dtlsParameters });
@@ -113,7 +114,7 @@ describe('WebRtcTransport', () => {
 
 					return { id: producerId };
 				}
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		const producer = await webRtcTransport.produce({
@@ -150,7 +151,7 @@ describe('WebRtcTransport', () => {
 						rtpParameters,
 					};
 				}
-			} [method] ?? (() => expect(true).toBe(false)))();
+			}[method] ?? (() => expect(true).toBe(false)))();
 		});
 
 		const pipeConsumer = await webRtcTransport.consume({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
 		"resolveJsonModule": true,
 		"esModuleInterop": true,
 	},
-	"include": ["src"],
+	"include": ["src", "__tests__"],
 	"exclude": ["node_modules", "connect.js"]
 }


### PR DESCRIPTION
This PR will enable lint for tests.

It will:

1. remove `__tests__` from `.eslintignore`
2. add `__tests__` to include array in `.tsconfig.json`
3. make existing tests pass lint