### PR TITLE
test: add unit-tests for middleware modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 connect.js
+jest.config.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,8 +2,7 @@
 	"parser": "@typescript-eslint/parser",
 	"parserOptions": {
 		"ecmaVersion": "latest",
-		"sourceType": "module",
-		"project": "./tsconfig.json"
+		"sourceType": "module"
 	},
 	"extends": ["plugin:@typescript-eslint/recommended"],
 	"env": { "node": true },

--- a/__mocks__/ConsumerMock.ts
+++ b/__mocks__/ConsumerMock.ts
@@ -1,4 +1,4 @@
-export default class ProducerMock {
+export default class ConsumerMock {
 	id = 'id';
 
 	resume = jest.fn();

--- a/__mocks__/ConsumerMock.ts
+++ b/__mocks__/ConsumerMock.ts
@@ -1,0 +1,9 @@
+export default class ProducerMock {
+	id = 'id';
+
+	resume = jest.fn();
+	pause = jest.fn();
+	setPreferredLayers = jest.fn();
+	setPriority = jest.fn();
+	requestKeyFrame = jest.fn();
+}

--- a/__mocks__/ProducerMock.ts
+++ b/__mocks__/ProducerMock.ts
@@ -1,0 +1,12 @@
+import EventEmitter from 'events';
+
+export default class ProducerMock extends EventEmitter {
+	id = 'id';
+	appData = {
+		remoteClosed: false
+	};
+
+	close = jest.fn();
+	resume = jest.fn();
+	pause = jest.fn();
+}

--- a/__mocks__/tsconfig.json
+++ b/__mocks__/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@tsconfig/node18/tsconfig.json",
+    "compilerOptions": {
+		"experimentalDecorators": true,
+		"resolveJsonModule": true,
+    },
+	"include": ["**/*.ts"]
+}

--- a/__tests__/tsconfig.json
+++ b/__tests__/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@tsconfig/node18/tsconfig.json",
+    "compilerOptions": {
+		"experimentalDecorators": true,
+		"resolveJsonModule": true,
+    },
+	"include": ["**/*.ts"]
+}

--- a/__tests__/unit-tests/middlewares/breakoutMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/breakoutMiddleware.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
 	jest.clearAllMocks();
 });
 
-test('Should throw on room not found', async () => {
+test('joinRoom() - Should throw on room not found', async () => {
 	const room = {
 		id: 'id',
 		rooms: List<Room>(),
@@ -37,7 +37,7 @@ test('Should throw on room not found', async () => {
 	await expect(sut(context, next)).rejects.toThrow();
 });
 
-test('Should handle joinRoom and call addPeer on breakoutRoom', async () => {
+test('joinRoom() - Should call addPeer on breakoutRoom', async () => {
 	const spyAddPeer = jest.fn();
 	const breakOutRoomToJoin = { id: SESSION_ID, addPeer: spyAddPeer } as unknown as Room;
 	const room = {
@@ -105,7 +105,7 @@ test('Should not handle unrelated methods', async () => {
 	expect(context.handled).toBeFalsy();
 });
 
-test('Should throw on createRoom when peer not authorized', async () => {
+test('createRoom() - Should throw when peer not authorized', async () => {
 	const room = {
 		id: 'id',
 		sessionId: SESSION_ID,
@@ -130,7 +130,7 @@ test('Should throw on createRoom when peer not authorized', async () => {
 	await expect(sut(context, next)).rejects.toThrow();
 });
 
-test('Should ', async () => {
+test('createRoom() - Should add room and notify peers', async () => {
 	const addRoom = jest.fn();
 	const notifyPeers = jest.fn();
 	const room = {

--- a/__tests__/unit-tests/middlewares/breakoutMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/breakoutMiddleware.test.ts
@@ -5,15 +5,15 @@ import * as checkSessionId from '../../../src/common/checkSessionId';
 import { createBreakoutMiddleware } from '../../../src/middlewares/breakoutMiddleware';
 import { List } from 'edumeet-common';
 import { userRoles } from '../../../src/common/authorization';
-import MediaService from '../../../src/MediaService';
+
+const next = jest.fn();
+const SESSION_ID = 'sessionId';
 
 afterEach(() => {
 	jest.clearAllMocks();
 });
 
 test('Should throw on room not found', async () => {
-	const SESSION_ID = 'sessionId';
-	const next = jest.fn();
 	const room = {
 		id: 'id',
 		rooms: List<Room>(),
@@ -38,8 +38,6 @@ test('Should throw on room not found', async () => {
 });
 
 test('Should handle joinRoom and call addPeer on breakoutRoom', async () => {
-	const SESSION_ID = 'sessionId';
-	const next = jest.fn();
 	const spyAddPeer = jest.fn();
 	const breakOutRoomToJoin = { id: SESSION_ID, addPeer: spyAddPeer } as unknown as Room;
 	const room = {
@@ -72,7 +70,6 @@ test('Should handle joinRoom and call addPeer on breakoutRoom', async () => {
 });
 
 test('Should call next middleware on wrong session', async () => {
-	const next = jest.fn();
 	const spyThisSession = jest.spyOn(checkSessionId, 'thisSession');
 	const room = { sessionId: 'id1' } as unknown as Room;
 	const options = { room } as unknown as MiddlewareOptions;
@@ -92,7 +89,6 @@ test('Should call next middleware on wrong session', async () => {
 });
 
 test('Should not handle unrelated methods', async () => {
-	const next = jest.fn();
 	const room = { id: 'id' } as unknown as Room;
 	const options = { room } as unknown as MiddlewareOptions;
 	const sut = createBreakoutMiddleware(options);
@@ -110,8 +106,6 @@ test('Should not handle unrelated methods', async () => {
 });
 
 test('Should throw on createRoom when peer not authorized', async () => {
-	const SESSION_ID = 'sessionId';
-	const next = jest.fn();
 	const room = {
 		id: 'id',
 		sessionId: SESSION_ID,
@@ -137,8 +131,6 @@ test('Should throw on createRoom when peer not authorized', async () => {
 });
 
 test('Should ', async () => {
-	const SESSION_ID = 'sessionId';
-	const next = jest.fn();
 	const addRoom = jest.fn();
 	const notifyPeers = jest.fn();
 	const room = {

--- a/__tests__/unit-tests/middlewares/breakoutMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/breakoutMiddleware.test.ts
@@ -1,0 +1,175 @@
+import { MiddlewareOptions } from '../../../src/common/types';
+import { PeerContext } from '../../../src/Peer';
+import Room from '../../../src/Room';
+import * as checkSessionId from '../../../src/common/checkSessionId';
+import { createBreakoutMiddleware } from '../../../src/middlewares/breakoutMiddleware';
+import { List } from 'edumeet-common';
+import { userRoles } from '../../../src/common/authorization';
+import MediaService from '../../../src/MediaService';
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+test('Should throw on room not found', async () => {
+	const SESSION_ID = 'sessionId';
+	const next = jest.fn();
+	const room = {
+		id: 'id',
+		rooms: List<Room>(),
+		sessionId: SESSION_ID
+	} as unknown as Room;
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createBreakoutMiddleware(options);
+
+	const peer = { roles: [] };
+	const message = { 
+		method: 'joinRoom',
+		data: {
+			sessionId: SESSION_ID
+		} };
+
+	const context = {
+		peer,
+		message,
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('Should handle joinRoom and call addPeer on breakoutRoom', async () => {
+	const SESSION_ID = 'sessionId';
+	const next = jest.fn();
+	const spyAddPeer = jest.fn();
+	const breakOutRoomToJoin = { id: SESSION_ID, addPeer: spyAddPeer } as unknown as Room;
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID,
+		rooms: List<Room>(),
+	} as unknown as Room;
+
+	room.rooms.add(breakOutRoomToJoin);
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createBreakoutMiddleware(options);
+
+	const peer = { roles: [] };
+	const message = {
+		method: 'joinRoom',
+		data: {
+			sessionId: SESSION_ID
+		}
+	};
+	const context = {
+		peer,
+		message,
+		handled: false
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(spyAddPeer).toHaveBeenCalled();
+	expect(context.handled).toBeTruthy();
+});
+
+test('Should call next middleware on wrong session', async () => {
+	const next = jest.fn();
+	const spyThisSession = jest.spyOn(checkSessionId, 'thisSession');
+	const room = { sessionId: 'id1' } as unknown as Room;
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createBreakoutMiddleware(options);
+
+	const message = { data: { sessionId: 'id2' } };
+
+	const context = {
+		message,
+		handled: false
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(spyThisSession).toHaveBeenCalled();
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should not handle unrelated methods', async () => {
+	const next = jest.fn();
+	const room = { id: 'id' } as unknown as Room;
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createBreakoutMiddleware(options);
+
+	const message = {};
+
+	const context = {
+		message,
+		handled: false
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should throw on createRoom when peer not authorized', async () => {
+	const SESSION_ID = 'sessionId';
+	const next = jest.fn();
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID,
+		rooms: List<Room>(),
+	} as unknown as Room;
+
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createBreakoutMiddleware(options);
+
+	const peer = { roles: [] };
+	const message = {
+		method: 'createRoom',
+		data: {
+			sessionId: SESSION_ID
+		}
+	};
+	const context = {
+		peer,
+		message,
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('Should ', async () => {
+	const SESSION_ID = 'sessionId';
+	const next = jest.fn();
+	const addRoom = jest.fn();
+	const notifyPeers = jest.fn();
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID,
+		rooms: List<Room>(),
+		addRoom,
+		notifyPeers
+	} as unknown as Room;
+
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createBreakoutMiddleware(options);
+
+	const peer = { roles: [ userRoles.NORMAL ] };
+	const message = {
+		method: 'createRoom',
+		data: {
+			name: 'name',
+			sessionId: SESSION_ID
+		}
+	};
+	const context = {
+		peer,
+		message,
+		response: {},
+		handled: false
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(addRoom).toHaveBeenCalled();
+	expect(notifyPeers).toHaveBeenCalled();
+	expect(context.handled).toBeTruthy();
+});

--- a/__tests__/unit-tests/middlewares/chatMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/chatMiddleware.test.ts
@@ -5,9 +5,7 @@ import Room from '../../../src/Room';
 import * as checkSessionId from '../../../src/common/checkSessionId';
 import { userRoles } from '../../../src/common/authorization';
 
-const next = jest.fn().mockImplementation(() => {
-	return 'NextWasCalled';
-});
+const next = jest.fn();
 
 afterEach(() => {
 	jest.clearAllMocks();
@@ -24,7 +22,6 @@ test('Should throw on peer not authorized', async () => {
 	const context = {
 		peer,
 		message,
-		handled: false
 	} as unknown as PeerContext;
 
 	await expect(sut(context, next)).rejects.toThrow();
@@ -45,10 +42,9 @@ test('Should call next middleware on wrong session', async () => {
 		handled: false
 	} as unknown as PeerContext;
 
-	const result = await sut(context, next);
+	await sut(context, next);
 
 	expect(spyThisSession).toHaveBeenCalled();
-	expect(result).toBe('NextWasCalled');
 	expect(context.handled).toBeFalsy();
 });
 
@@ -93,8 +89,7 @@ test('Should call next middleware if not chat message', async () => {
 		handled: false
 	} as unknown as PeerContext;
 
-	const result = await sut(context, next);
+	await sut(context, next);
 
-	expect(result).toBe('NextWasCalled');
 	expect(context.handled).toBeFalsy();
 });

--- a/__tests__/unit-tests/middlewares/chatMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/chatMiddleware.test.ts
@@ -1,0 +1,100 @@
+import { ChatMessage, MiddlewareOptions } from '../../../src/common/types';
+import { createChatMiddleware } from '../../../src/middlewares/chatMiddleware';
+import { PeerContext } from '../../../src/Peer';
+import Room from '../../../src/Room';
+import * as checkSessionId from '../../../src/common/checkSessionId';
+import { userRoles } from '../../../src/common/authorization';
+
+const next = jest.fn().mockImplementation(() => {
+	return 'NextWasCalled';
+});
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+test('Should throw on peer not authorized', async () => {
+	const room = { id: 'id' } as unknown as Room;
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createChatMiddleware(options);
+
+	const peer = { roles: [] };
+	const message = { method: 'chatMessage' };
+
+	const context = {
+		peer,
+		message,
+		handled: false
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('Should call next middleware on wrong session', async () => {
+	const spyThisSession = jest.spyOn(checkSessionId, 'thisSession');
+	const room = { id: 'id', sessionId: 'id1' } as unknown as Room;
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createChatMiddleware(options);
+
+	const peer = { roles: [] };
+	const message = { data: { sessionId: 'id2' } };
+
+	const context = {
+		peer,
+		message,
+		handled: false
+	} as unknown as PeerContext;
+
+	const result = await sut(context, next);
+
+	expect(spyThisSession).toHaveBeenCalled();
+	expect(result).toBe('NextWasCalled');
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should notify peers on authorized peer sending chat message', async () => {
+	const spyNotify = jest.fn();
+	const room = { id: 'id', notifyPeers: spyNotify } as unknown as Room;
+	const chatHistory: ChatMessage[] = [];
+	const options = { room, chatHistory } as unknown as MiddlewareOptions;
+	const sut = createChatMiddleware(options);
+
+	const peer = { roles: [ userRoles.NORMAL ] };
+	const message = {
+		method: 'chatMessage',
+		data: {
+
+		}
+	};
+
+	const context = {
+		peer,
+		message,
+		handled: false
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(spyNotify.mock.calls[0][0]).toBe('chatMessage');
+	expect(context.handled).toBeTruthy();
+});
+
+test('Should call next middleware if not chat message', async () => {
+	const room = { id: 'id' } as unknown as Room;
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createChatMiddleware(options);
+
+	const peer = { roles: [ userRoles.NORMAL ] };
+	const message = {};
+
+	const context = {
+		peer,
+		message,
+		handled: false
+	} as unknown as PeerContext;
+
+	const result = await sut(context, next);
+
+	expect(result).toBe('NextWasCalled');
+	expect(context.handled).toBeFalsy();
+});

--- a/__tests__/unit-tests/middlewares/consumerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/consumerMiddleware.test.ts
@@ -10,9 +10,9 @@ test.each([
 	[ 'id', 'wrong', 'id', 'id', false ],
 	[ 'wrong', 'id', 'id', 'id', false ],
 	[ 'id', 'id', 'id', 'id', true ]
-])('Should not handle messages for wrong consumer or router', async (routerId, routerIdInMessage, consumerId, consumerIdInMessage, wasHandled) => {
+])('Should not handle messages for wrong consumer or router', async (routerId, routerIdInMessage, dataConsumerId, dataConsumerIdInMessage, wasHandled) => {
 	const consumer = {
-		id: consumerId,
+		id: dataConsumerId,
 		router: {
 			id: routerId
 		},
@@ -26,7 +26,7 @@ test.each([
 			method: 'consumerClosed',
 			data: {
 				routerId: routerIdInMessage,
-				consumerId: consumerIdInMessage
+				consumerId: dataConsumerIdInMessage
 			}
 		}
 	} as MediaNodeConnectionContext;

--- a/__tests__/unit-tests/middlewares/consumerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/consumerMiddleware.test.ts
@@ -1,4 +1,3 @@
-import exp from 'constants';
 import { Consumer } from '../../../src/media/Consumer';
 import { MediaNodeConnectionContext } from '../../../src/media/MediaNodeConnection';
 import { createConsumerMiddleware } from '../../../src/middlewares/consumerMiddleware';
@@ -6,22 +5,25 @@ import { createConsumerMiddleware } from '../../../src/middlewares/consumerMiddl
 const next = jest.fn();
 
 test.each([
-	[ 'id', 'id', 'id', 'wrong' ],
-	[ 'id', 'id', 'wrong', 'id' ],
-	[ 'id', 'wrong', 'id', 'id' ],
-	[ 'wrong', 'id', 'id', 'id' ]
-])('Should not handle messages for wrong consumer or router', async (routerId, routerIdInMessage, consumerId, consumerIdInMessage) => {
+	[ 'id', 'id', 'id', 'wrong', false ],
+	[ 'id', 'id', 'wrong', 'id', false ],
+	[ 'id', 'wrong', 'id', 'id', false ],
+	[ 'wrong', 'id', 'id', 'id', false ],
+	[ 'id', 'id', 'id', 'id', true ]
+])('Should not handle messages for wrong consumer or router', async (routerId, routerIdInMessage, consumerId, consumerIdInMessage, wasHandled) => {
 	const consumer = {
 		id: consumerId,
 		router: {
 			id: routerId
-		}
+		},
+		close: jest.fn()
 	} as unknown as Consumer;
 	const sut = createConsumerMiddleware({ consumer });
 
 	const context = {
 		handled: false,
 		message: {
+			method: 'consumerClosed',
 			data: {
 				routerId: routerIdInMessage,
 				consumerId: consumerIdInMessage
@@ -30,7 +32,7 @@ test.each([
 	} as MediaNodeConnectionContext;
 
 	await sut(context, next);
-	expect(context.handled).toBeFalsy();
+	expect(context.handled).toBe(wasHandled);
 });
 
 test('Should not handle unrelated methods', async () => {

--- a/__tests__/unit-tests/middlewares/consumerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/consumerMiddleware.test.ts
@@ -1,0 +1,195 @@
+import exp from 'constants';
+import { Consumer } from '../../../src/media/Consumer';
+import { MediaNodeConnectionContext } from '../../../src/media/MediaNodeConnection';
+import { createConsumerMiddleware } from '../../../src/middlewares/consumerMiddleware';
+
+const next = jest.fn();
+
+test.each([
+	[ 'id', 'id', 'id', 'wrong' ],
+	[ 'id', 'id', 'wrong', 'id' ],
+	[ 'id', 'wrong', 'id', 'id' ],
+	[ 'wrong', 'id', 'id', 'id' ]
+])('Should not handle messages for wrong consumer or router', async (routerId, routerIdInMessage, consumerId, consumerIdInMessage) => {
+	const consumer = {
+		id: consumerId,
+		router: {
+			id: routerId
+		}
+	} as unknown as Consumer;
+	const sut = createConsumerMiddleware({ consumer });
+
+	const context = {
+		handled: false,
+		message: {
+			data: {
+				routerId: routerIdInMessage,
+				consumerId: consumerIdInMessage
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should not handle unrelated methods', async () => {
+	const consumer = {
+		id: 'id',
+		router: {
+			id: 'id'
+		},
+	} as unknown as Consumer;
+	const sut = createConsumerMiddleware({ consumer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'non-existing-method',
+			data: {
+				routerId: 'id',
+				consumerId: 'id'
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should close consumer', async () => {
+	const spy = jest.fn();
+	const consumer = {
+		id: 'id',
+		router: {
+			id: 'id'
+		},
+		close: spy
+	} as unknown as Consumer;
+	const sut = createConsumerMiddleware({ consumer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'consumerClosed',
+			data: {
+				routerId: 'id',
+				consumerId: 'id'
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeTruthy();
+	expect(spy).toHaveBeenCalled();
+});
+
+test('Should pause producer', async () => {
+	const spy = jest.fn();
+	const consumer = {
+		id: 'id',
+		router: {
+			id: 'id'
+		},
+		setProducerPaused: spy
+	} as unknown as Consumer;
+	const sut = createConsumerMiddleware({ consumer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'consumerProducerPaused',
+			data: {
+				routerId: 'id',
+				consumerId: 'id'
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeTruthy();
+	expect(spy).toHaveBeenCalled();
+});
+
+test('Should resume producer', async () => {
+	const spy = jest.fn();
+	const consumer = {
+		id: 'id',
+		router: {
+			id: 'id'
+		},
+		setProducerResumed: spy
+	} as unknown as Consumer;
+	const sut = createConsumerMiddleware({ consumer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'consumerProducerResumed',
+			data: {
+				routerId: 'id',
+				consumerId: 'id'
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeTruthy();
+	expect(spy).toHaveBeenCalled();
+});
+
+test('Should set score', async () => {
+	const spy = jest.fn();
+	const consumer = {
+		id: 'id',
+		router: {
+			id: 'id'
+		},
+		setScore: spy
+	} as unknown as Consumer;
+	const sut = createConsumerMiddleware({ consumer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'consumerScore',
+			data: {
+				score: 'score',
+				routerId: 'id',
+				consumerId: 'id'
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeTruthy();
+	expect(spy).toHaveBeenCalledWith('score');
+});
+
+test('Should set consumers layer', async () => {
+	const spy = jest.fn();
+	const consumer = {
+		id: 'id',
+		router: {
+			id: 'id'
+		},
+		setLayers: spy
+	} as unknown as Consumer;
+	const sut = createConsumerMiddleware({ consumer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'consumerLayersChanged',
+			data: {
+				layers: 'layers',
+				routerId: 'id',
+				consumerId: 'id'
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeTruthy();
+	expect(spy).toHaveBeenCalledWith('layers');
+});

--- a/__tests__/unit-tests/middlewares/dataConsumerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/dataConsumerMiddleware.test.ts
@@ -1,0 +1,89 @@
+import { Consumer } from '../../../src/media/Consumer';
+import { DataConsumer } from '../../../src/media/DataConsumer';
+import { MediaNodeConnectionContext } from '../../../src/media/MediaNodeConnection';
+import { createConsumerMiddleware } from '../../../src/middlewares/consumerMiddleware';
+import { createDataConsumerMiddleware } from '../../../src/middlewares/dataConsumerMiddleware';
+
+const next = jest.fn();
+
+test.each([
+	[ 'id', 'id', 'id', 'wrong', false ],
+	[ 'id', 'id', 'wrong', 'id', false ],
+	[ 'id', 'wrong', 'id', 'id', false ],
+	[ 'wrong', 'id', 'id', 'id', false ],
+	[ 'id', 'id', 'id', 'id', true ]
+])('Should not handle messages for wrong consumer or router', async (routerId, routerIdInMessage, consumerId, consumerIdInMessage, wasHandled) => {
+	const dataConsumer = {
+		id: consumerId,
+		router: {
+			id: routerId
+		},
+		close: jest.fn()
+	} as unknown as DataConsumer;
+	const sut = createDataConsumerMiddleware({ dataConsumer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'dataConsumerClosed',
+			data: {
+				routerId: routerIdInMessage,
+				dataConsumerId: consumerIdInMessage
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBe(wasHandled);
+});
+
+test('Should not handle unrelated methods', async () => {
+	const dataConsumer = {
+		id: 'id',
+		router: {
+			id: 'id'
+		},
+	} as unknown as DataConsumer;
+	const sut = createDataConsumerMiddleware({ dataConsumer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'non-existing-method',
+			data: {
+				routerId: 'id',
+				dataConsumerId: 'id'
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should close dataConsumer', async () => {
+	const spy = jest.fn();
+	const dataConsumer = {
+		id: 'id',
+		router: {
+			id: 'id'
+		},
+		close: spy
+	} as unknown as DataConsumer;
+	const sut = createDataConsumerMiddleware({ dataConsumer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'dataConsumerClosed',
+			data: {
+				routerId: 'id',
+				dataConsumerId: 'id'
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeTruthy();
+	expect(spy).toHaveBeenCalled();
+});

--- a/__tests__/unit-tests/middlewares/dataProducerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/dataProducerMiddleware.test.ts
@@ -1,6 +1,6 @@
-import { DataConsumer } from '../../../src/media/DataConsumer';
+import { DataProducer } from '../../../src/media/DataProducer';
 import { MediaNodeConnectionContext } from '../../../src/media/MediaNodeConnection';
-import { createDataConsumerMiddleware } from '../../../src/middlewares/dataConsumerMiddleware';
+import { createDataProducerMiddleware } from '../../../src/middlewares/dataProducerMiddleware';
 
 const next = jest.fn();
 
@@ -10,23 +10,23 @@ test.each([
 	[ 'id', 'wrong', 'id', 'id', false ],
 	[ 'wrong', 'id', 'id', 'id', false ],
 	[ 'id', 'id', 'id', 'id', true ]
-])('Should not handle messages for wrong consumer or router', async (routerId, routerIdInMessage, consumerId, consumerIdInMessage, wasHandled) => {
-	const dataConsumer = {
-		id: consumerId,
+])('Should not handle messages for wrong consumer or router', async (routerId, routerIdInMessage, producerId, producerIdInMessage, wasHandled) => {
+	const dataProducer = {
+		id: producerId,
 		router: {
 			id: routerId
 		},
 		close: jest.fn()
-	} as unknown as DataConsumer;
-	const sut = createDataConsumerMiddleware({ dataConsumer });
+	} as unknown as DataProducer;
+	const sut = createDataProducerMiddleware({ dataProducer });
 
 	const context = {
 		handled: false,
 		message: {
-			method: 'dataConsumerClosed',
+			method: 'dataProducerClosed',
 			data: {
 				routerId: routerIdInMessage,
-				dataConsumerId: consumerIdInMessage
+				dataProducerId: producerIdInMessage
 			}
 		}
 	} as MediaNodeConnectionContext;
@@ -36,13 +36,13 @@ test.each([
 });
 
 test('Should not handle unrelated methods', async () => {
-	const dataConsumer = {
+	const dataProducer = {
 		id: 'id',
 		router: {
 			id: 'id'
 		},
-	} as unknown as DataConsumer;
-	const sut = createDataConsumerMiddleware({ dataConsumer });
+	} as unknown as DataProducer;
+	const sut = createDataProducerMiddleware({ dataProducer });
 
 	const context = {
 		handled: false,
@@ -50,7 +50,7 @@ test('Should not handle unrelated methods', async () => {
 			method: 'non-existing-method',
 			data: {
 				routerId: 'id',
-				dataConsumerId: 'id'
+				dataProducerId: 'id'
 			}
 		}
 	} as MediaNodeConnectionContext;
@@ -59,24 +59,24 @@ test('Should not handle unrelated methods', async () => {
 	expect(context.handled).toBeFalsy();
 });
 
-test('Should close dataConsumer', async () => {
+test('Should close dataProducer', async () => {
 	const spy = jest.fn();
-	const dataConsumer = {
+	const dataProducer = {
 		id: 'id',
 		router: {
 			id: 'id'
 		},
 		close: spy
-	} as unknown as DataConsumer;
-	const sut = createDataConsumerMiddleware({ dataConsumer });
+	} as unknown as DataProducer;
+	const sut = createDataProducerMiddleware({ dataProducer });
 
 	const context = {
 		handled: false,
 		message: {
-			method: 'dataConsumerClosed',
+			method: 'dataProducerClosed',
 			data: {
 				routerId: 'id',
-				dataConsumerId: 'id'
+				dataProducerId: 'id'
 			}
 		}
 	} as MediaNodeConnectionContext;

--- a/__tests__/unit-tests/middlewares/fileMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/fileMiddleware.test.ts
@@ -1,0 +1,115 @@
+import { userRoles } from '../../../src/common/authorization';
+import { FileMessage, MiddlewareOptions } from '../../../src/common/types';
+import { createFileMiddleware } from '../../../src/middlewares/fileMiddleware';
+import { Peer, PeerContext } from '../../../src/Peer';
+import Room from '../../../src/Room';
+
+const SESSION_ID = 'sessionId';
+
+test('Should not handle wrong session', async () => {
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createFileMiddleware(options);
+
+	const next = jest.fn();
+	const context = {
+		handled: false,
+		message: {
+			method: 'sendFile',
+			data: {
+				sessionId: 'wrong session'
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should not handle unknown method', async () => {
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createFileMiddleware(options);
+
+	const next = jest.fn();
+	const context = {
+		handled: false,
+		message: {
+			method: 'non-existing-method',
+			data: {
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('sendFile() - Should throw on missing permissions', async () => {
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createFileMiddleware(options);
+	const next = jest.fn();
+	const peer = {
+		roles: []
+	} as unknown as Peer;
+	const context = {
+		peer,
+		message: {
+			method: 'sendFile',
+			data: {
+				sessionId: SESSION_ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('sendFile() - Should ', async () => {
+	const spyNotifyPeers = jest.fn();
+	const spyPushToHistory = jest.fn();
+	const fileHistory = {
+		push: spyPushToHistory
+	} as unknown as FileMessage[];
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID,
+		notifyPeers: spyNotifyPeers
+	} as unknown as Room;
+	const options = { room, fileHistory } as MiddlewareOptions;
+	const sut = createFileMiddleware(options);
+	const peer = {
+		roles: [ userRoles.NORMAL ] 
+	};
+
+	const next = jest.fn();
+	const context = {
+		handled: false,
+		peer,
+		message: {
+			method: 'sendFile',
+			data: {
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+
+	expect(spyNotifyPeers.mock.calls[0][0]).toBe('sendFile');
+	expect(spyPushToHistory).toHaveBeenCalled();
+	expect(context.handled).toBeTruthy();
+});

--- a/__tests__/unit-tests/middlewares/initialMediaMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/initialMediaMiddleware.test.ts
@@ -1,0 +1,306 @@
+import EventEmitter from 'events';
+import { MiddlewareOptions } from '../../../src/common/types';
+import { WebRtcTransport } from '../../../src/media/WebRtcTransport';
+import MediaService from '../../../src/MediaService';
+import { createInitialMediaMiddleware } from '../../../src/middlewares/initialMediaMiddleware';
+import { Peer, PeerContext } from '../../../src/Peer';
+import Room from '../../../src/Room';
+
+const SESSION_ID = 'sessionId';
+
+class MockTransport extends EventEmitter {
+	id = 'id';
+	iceParameters = 'iceP';
+	iceCandidates = 'iceC';
+	dtlsParameters = 'dtlsP';
+	sctpParameters = 'sctpP';
+	connect = jest.fn();
+	restartIce = jest.fn();
+}
+
+const next = jest.fn();
+
+test('Should not handle wrong session', async () => {
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID
+	};
+	const mediaService = {
+		getRouter: jest.fn()
+	} as unknown as MediaService;
+	const options = { room, mediaService } as MiddlewareOptions;
+	const sut = createInitialMediaMiddleware(options);
+	const peer = {};
+	const message = {
+		data: {
+			sessionId: 'Not this session'
+		}
+	};
+	const context = {
+		handled: false,
+		peer,
+		message
+	} as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('getRouterRtpCapabilities() - should get rtpCapabilities', async () => {
+	const room = {} as Room;
+	const mediaService = {
+		getRouter: jest.fn()
+	} as unknown as MediaService;
+	const options = { room, mediaService } as MiddlewareOptions;
+	const sut = createInitialMediaMiddleware(options);
+	const peer = {
+		router: {
+			rtpCapabilities: 'rtp' 
+		}
+	} as unknown as Peer;
+	const message = {
+		method: 'getRouterRtpCapabilities',
+		data: {}
+	};
+	const context = {
+		response: {},
+		peer,
+		message
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.response.routerRtpCapabilities).toBe('rtp');
+	expect(context.handled).toBeTruthy();
+});
+
+test('Should get router form mediaService on missing peer router', async () => {
+	const room = {
+		sessionId: SESSION_ID
+	} as Room;
+	const spyGetRouter = jest.fn();
+	const mediaService = {
+		getRouter: spyGetRouter
+	} as unknown as MediaService;
+	const options = { room, mediaService } as MiddlewareOptions;
+	const sut = createInitialMediaMiddleware(options);
+	const peer = {
+		router: undefined
+	} as unknown as Peer;
+	const message = {
+		data: {
+			sessionId: SESSION_ID
+		}
+	};
+	const context = {
+		response: {},
+		peer,
+		message
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(spyGetRouter).toHaveBeenCalled();
+});
+
+test('createWebRtcTransport() - Should throw on no transport', async () => {
+	const room = {
+		sessionId: SESSION_ID
+	} as Room;
+	const options = { room } as MiddlewareOptions;
+	const sut = createInitialMediaMiddleware(options);
+	const peer = {
+		router: {
+			createWebRtcTransport: jest.fn()
+		}
+	} as unknown as Peer;
+	const message = {
+		method: 'createWebRtcTransport',
+		data: {
+			sessionId: SESSION_ID
+		}
+	};
+	const context = {
+		peer,
+		message
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('createWebRtcTransport() - Should transport life cycle', async () => {
+	const room = {
+		sessionId: SESSION_ID
+	} as Room;
+	const transport = new MockTransport();
+	const spyCreateTransport = jest.fn().mockImplementation(() => {
+		return transport;
+	});
+	const mediaService = {} as unknown as MediaService;
+	const options = { room, mediaService } as MiddlewareOptions;
+	const sut = createInitialMediaMiddleware(options);
+	const spyNotify = jest.fn();
+	const peer = {
+		router: {
+			createWebRtcTransport: spyCreateTransport
+		},
+		transports: new Map(),
+		notify: spyNotify
+	} as unknown as Peer;
+	const spyDelete = jest.spyOn(peer.transports, 'delete');
+	const message = {
+		method: 'createWebRtcTransport',
+		data: {
+			sessionId: SESSION_ID
+		}
+	};
+	const context = {
+		response: {},
+		peer,
+		message
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(spyCreateTransport).toHaveBeenCalled();
+	expect(context.handled).toBeTruthy();
+	expect(context.response.id).toBe(transport.id);
+	expect(context.response.iceCandidates).toBe(transport.iceCandidates);
+	expect(context.response.iceParameters).toBe(transport.iceParameters);
+	expect(context.response.dtlsParameters).toBe(transport.dtlsParameters);
+	expect(context.response.sctpParameters).toBe(transport.sctpParameters);
+	expect(spyNotify).not.toHaveBeenCalled();
+	expect(spyDelete).not.toHaveBeenCalled();
+
+	transport.emit('close');
+
+	expect(spyDelete).toHaveBeenCalled();
+	expect(spyNotify).toHaveBeenCalled();
+	expect(spyNotify.mock.calls[0][0].method).toBe('transportClosed');
+});
+
+test('connectWebRtcTransport() - Should connect transport', async () => {
+	const room = {
+		sessionId: SESSION_ID
+	} as Room;
+	const mediaService = {} as unknown as MediaService;
+	const options = { room, mediaService } as MiddlewareOptions;
+	const sut = createInitialMediaMiddleware(options);
+	const peer = {
+		router: { getRouter: jest.fn() },
+		transports: new Map(),
+	} as unknown as Peer;
+	const transport = new MockTransport() as unknown as WebRtcTransport;
+	const spyConnect = jest.spyOn(transport, 'connect');
+
+	peer.transports.set(transport.id, transport);
+	const message = {
+		method: 'connectWebRtcTransport',
+		data: {
+			sessionId: SESSION_ID,
+			transportId: 'id'
+		}
+	};
+	const context = {
+		peer,
+		message
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(spyConnect).toHaveBeenCalled();
+});
+
+test('connectWebRtcTransport() - Should throw on no transport', async () => {
+	const room = {
+		sessionId: SESSION_ID
+	} as Room;
+	const mediaService = {} as unknown as MediaService;
+	const options = { room, mediaService } as MiddlewareOptions;
+	const sut = createInitialMediaMiddleware(options);
+	const peer = {
+		router: { getRouter: jest.fn() },
+		transports: new Map(),
+	} as unknown as Peer;
+
+	const message = {
+		method: 'connectWebRtcTransport',
+		data: {
+			sessionId: SESSION_ID,
+			transportId: 'id'
+		}
+	};
+	const context = {
+		peer,
+		message
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('restartIce() - Should handle ice restart', async () => {
+	const room = {
+		sessionId: SESSION_ID
+	} as Room;
+	const mediaService = {} as unknown as MediaService;
+	const options = { room, mediaService } as MiddlewareOptions;
+	const sut = createInitialMediaMiddleware(options);
+	const peer = {
+		router: { getRouter: jest.fn() },
+		transports: new Map(),
+	} as unknown as Peer;
+
+	const message = {
+		method: 'restartIce',
+		data: {
+			sessionId: SESSION_ID,
+			transportId: 'id'
+		}
+	};
+	const context = {
+		peer,
+		message
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('restartIce() - Should throw on no transport', async () => {
+	const room = {
+		sessionId: SESSION_ID
+	} as Room;
+	const mediaService = {} as unknown as MediaService;
+	const options = { room, mediaService } as MiddlewareOptions;
+	const sut = createInitialMediaMiddleware(options);
+	const peer = {
+		router: { getRouter: jest.fn() },
+		transports: new Map(),
+	} as unknown as Peer;
+	const transport = new MockTransport() as unknown as WebRtcTransport;
+
+	peer.transports.set(transport.id, transport);
+	const spyRestartIce = jest.spyOn(transport, 'restartIce').mockImplementation(async () => {
+		return 'ice';
+	});
+
+	const message = {
+		method: 'restartIce',
+		data: {
+			sessionId: SESSION_ID,
+			transportId: 'id'
+		}
+	};
+	const context = {
+		peer,
+		response: {},
+		message
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(spyRestartIce).toHaveBeenCalled();
+	expect(context.response.iceParameters).toBe('ice');
+	expect(context.handled).toBeTruthy();
+});

--- a/__tests__/unit-tests/middlewares/joinMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/joinMiddleware.test.ts
@@ -1,0 +1,201 @@
+import { List } from 'edumeet-common';
+import { userRoles } from '../../../src/common/authorization';
+import { MiddlewareOptions } from '../../../src/common/types';
+import { DataProducer } from '../../../src/media/DataProducer';
+import { Producer } from '../../../src/media/Producer';
+import { createJoinMiddleware } from '../../../src/middlewares/joinMiddleware';
+import { Peer, PeerContext } from '../../../src/Peer';
+import Room from '../../../src/Room';
+
+import * as consuming from '../../../src/common/consuming';
+
+const next = jest.fn();
+const SESSION_ID = 'sessionId';
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+test('Should not handle unrelated message', async () => {
+	const room = {
+		sessionId: SESSION_ID,
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createJoinMiddleware(options);
+
+	const context = {
+		message: {
+			method: 'non-existing-method',
+			data: {
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should not handle wrong session', async () => {
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createJoinMiddleware(options);
+
+	const context = {
+		message: {
+			method: 'join',
+			data: {
+				sessionId: 'other ID'
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+});
+
+test('join() - Should throw on missing rtpCapabilities', async () => {
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID,
+		parent: false
+	} as unknown as Room;
+	const options = { room } as MiddlewareOptions;
+	const sut = createJoinMiddleware(options);
+
+	const context = {
+		message: {
+			method: 'join',
+			data: {
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('join() - Should join peer', async () => {
+	const spyCreateConsumer = jest.spyOn(consuming, 'createConsumer')
+		.mockImplementation(async () => { return; });
+	const spyCreateDataConsumer = jest.spyOn(consuming, 'createDataConsumer')
+		.mockImplementation(async () => { return; });
+	const fakePeer ={
+		peerInfo: 'getPeer',
+		producers: new Map<string, Producer>(),
+		dataProducers: new Map<string, DataProducer>()
+	};
+	const fakeProducer = {
+		id: 'id',
+		appData: {
+			sessionId: SESSION_ID
+		}
+	} as unknown as Producer;
+	const fakeDataProducer = {
+		id: 'id',
+		appData: {
+			sessionId: SESSION_ID
+		}
+	} as unknown as DataProducer;
+
+	fakePeer.producers.set(fakeProducer.id, fakeProducer);
+	fakePeer.dataProducers.set(fakeDataProducer.id, fakeDataProducer);
+	const spyGetPeers = jest.fn().mockImplementation(() => {
+		return [ fakePeer ];
+	});
+	const spyJoinPeer = jest.fn();
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID,
+		parent: false,
+		getPeers: spyGetPeers,
+		lobbyPeers: List<Peer>(),
+		joinPeer: spyJoinPeer,
+		locked: true
+	} as unknown as Room;
+	const lobbyPeer = { peerInfo: 'lobbyPeer' } as unknown as Peer;
+
+	room.lobbyPeers.add(lobbyPeer);
+	const options = { room } as MiddlewareOptions;
+	const sut = createJoinMiddleware(options);
+
+	const peer = {
+		displayName: '',
+		picture: '',
+		rtpCapabilities: '',
+		roles: [ userRoles.NORMAL ]
+	} as unknown as Peer;
+	const context = {
+		peer,
+		response: {},
+		message: {
+			method: 'join',
+			data: {
+				sessionId: SESSION_ID,
+				displayName: 'n',
+				picture: 'p',
+				rtpCapabilities: 'rtp'
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(peer.displayName).toBe(context.message.data.displayName);
+	expect(peer.picture).toBe(context.message.data.picture);
+	expect(peer.rtpCapabilities).toBe(context.message.data.rtpCapabilities);
+	expect(context.handled).toBeTruthy();
+	expect(context.response.lobbyPeers).toEqual([ lobbyPeer.peerInfo ]);
+	expect(context.response.locked).toBeTruthy();
+	expect(spyGetPeers).toHaveBeenCalled();
+	expect(spyJoinPeer).toHaveBeenCalled();
+	expect(spyCreateConsumer).toHaveBeenCalled();
+	expect(spyCreateDataConsumer).toHaveBeenCalled();
+});
+
+test('join() - Should not return lobbyPeers on missing permission', async () => {
+	const spyGetPeers = jest.fn().mockImplementation(() => {
+		return [];
+	});
+	const spyJoinPeer = jest.fn();
+	const room = {
+		id: 'id',
+		sessionId: SESSION_ID,
+		parent: false,
+		getPeers: spyGetPeers,
+		joinPeer: spyJoinPeer,
+		locked: false
+	} as unknown as Room;
+	const options = { room } as MiddlewareOptions;
+	const sut = createJoinMiddleware(options);
+
+	const peer = {
+		displayName: '',
+		picture: '',
+		rtpCapabilities: '',
+		roles: [ ]
+	} as unknown as Peer;
+	const context = {
+		peer,
+		response: {},
+		message: {
+			method: 'join',
+			data: {
+				sessionId: SESSION_ID,
+				rtpCapabilities: 'rtp'
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(context.response.lobbyPeers).toEqual([]);
+	expect(context.response.locked).toBeFalsy();
+	expect(spyGetPeers).toHaveBeenCalled();
+	expect(spyJoinPeer).toHaveBeenCalled();
+});

--- a/__tests__/unit-tests/middlewares/lobbyMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/lobbyMiddleware.test.ts
@@ -1,0 +1,195 @@
+import { List, Next } from 'edumeet-common';
+import { userRoles } from '../../../src/common/authorization';
+import { MiddlewareOptions } from '../../../src/common/types';
+import { createLobbyMiddleware } from '../../../src/middlewares/lobbyMiddleware';
+import { Peer, PeerContext } from '../../../src/Peer';
+import Room from '../../../src/Room';
+
+const SESSION_ID = 'sessionId';
+const next = jest.fn as unknown as Next;
+
+test('Should not handle unrelated message', async () => {
+	const room = {
+		sessionId: SESSION_ID,
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLobbyMiddleware(options);
+
+	const context = {
+		message: {
+			method: 'non-existing-method',
+			data: {
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should not handle wrong session', async () => {
+	const room = {
+		sessionId: SESSION_ID,
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLobbyMiddleware(options);
+
+	const context = {
+		message: {
+			data: {
+				sessionId: 'wrong id',
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('promotePeer() - Should throw on not authorized', async () => {
+	const room = {
+		sessionId: SESSION_ID,
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const peer = {
+		roles: []
+	};
+	const sut = createLobbyMiddleware(options);
+
+	const context = {
+		peer,
+		message: {
+			method: 'promotePeer',
+			data: {
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('promotePeer() - Should throw on peer not found', async () => {
+	const room = {
+		sessionId: SESSION_ID,
+		lobbyPeers: List<Peer>()
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const peer = {
+		roles: [ userRoles.NORMAL ]
+	};
+	const sut = createLobbyMiddleware(options);
+
+	const context = {
+		peer,
+		message: {
+			method: 'promotePeer',
+			data: {
+				peerId: 'wrong id',
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('promotePeer() - Should promote peer on happy path', async () => {
+	const spyPromotePeer = jest.fn();
+	const room = {
+		sessionId: SESSION_ID,
+		lobbyPeers: List<Peer>(),
+		promotePeer: spyPromotePeer
+	} as unknown as Room;
+	const lobbyPeer = {
+		id: 'id'
+	} as unknown as Peer;
+
+	room.lobbyPeers.add(lobbyPeer);
+
+	const options = { room } as MiddlewareOptions;
+	const peer = {
+		roles: [ userRoles.NORMAL ]
+	};
+	const sut = createLobbyMiddleware(options);
+
+	const context = {
+		peer,
+		message: {
+			method: 'promotePeer',
+			data: {
+				peerId: 'id',
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+    
+	expect(spyPromotePeer).toHaveBeenCalled();
+	expect(context.handled).toBeTruthy();
+});
+
+test('promoteAllPeers() - Should promote peers on happy path', async () => {
+	const spyPromoteAllPeers = jest.fn();
+	const room = {
+		sessionId: SESSION_ID,
+		lobbyPeers: List<Peer>(),
+		promoteAllPeers: spyPromoteAllPeers
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const peer = {
+		roles: [ userRoles.NORMAL ]
+	};
+	const sut = createLobbyMiddleware(options);
+
+	const context = {
+		peer,
+		message: {
+			method: 'promoteAllPeers',
+			data: {
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+    
+	expect(spyPromoteAllPeers).toHaveBeenCalled();
+	expect(context.handled).toBeTruthy();
+});
+
+test('promoteAllPeers() - Should throw on not authorized', async () => {
+	const spyPromoteAllPeers = jest.fn();
+	const room = {
+		sessionId: SESSION_ID,
+		lobbyPeers: List<Peer>(),
+		promoteAllPeers: spyPromoteAllPeers
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const peer = {
+		roles: [ ]
+	};
+	const sut = createLobbyMiddleware(options);
+
+	const context = {
+		peer,
+		message: {
+			method: 'promoteAllPeers',
+			data: {
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});

--- a/__tests__/unit-tests/middlewares/lobbyPeerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/lobbyPeerMiddleware.test.ts
@@ -1,0 +1,114 @@
+import { Next } from 'edumeet-common';
+import { MiddlewareOptions } from '../../../src/common/types';
+import { createLobbyMiddleware } from '../../../src/middlewares/lobbyMiddleware';
+import { createLobbyPeerMiddleware } from '../../../src/middlewares/lobbyPeerMiddleware';
+import { PeerContext } from '../../../src/Peer';
+import Room from '../../../src/Room';
+
+const SESSION_ID = 'sessionId';
+const next = jest.fn as unknown as Next;
+
+test('Should not handle unrelated message', async () => {
+	const room = {
+		sessionId: SESSION_ID,
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLobbyPeerMiddleware(options);
+
+	const context = {
+		message: {
+			method: 'non-existing-method',
+			data: {
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should not handle wrong session', async () => {
+	const room = {
+		sessionId: SESSION_ID,
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLobbyPeerMiddleware(options);
+
+	const context = {
+		message: {
+			data: {
+				sessionId: 'wrong id',
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('changeDisplayName() - Should notify peers on happy path', async () => {
+	const spyNotifyPeers = jest.fn();
+	const room = {
+		sessionId: SESSION_ID,
+		notifyPeers: spyNotifyPeers
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLobbyPeerMiddleware(options);
+	const peer = {
+		displayName: ''
+	};
+
+	const context = {
+		peer,
+		message: {
+			method: 'changeDisplayName',
+			data: {
+				displayName: 'n',
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(peer.displayName).toBe('n');
+	expect(spyNotifyPeers).toHaveBeenCalled();
+});
+
+test('changePicture() - Should notify peers on happy path', async () => {
+	const spyNotifyPeers = jest.fn();
+	const room = {
+		sessionId: SESSION_ID,
+		notifyPeers: spyNotifyPeers
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLobbyPeerMiddleware(options);
+	const peer = {
+		picture: ''
+	};
+
+	const context = {
+		peer,
+		message: {
+			method: 'changePicture',
+			data: {
+				picture: 'p',
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(peer.picture).toBe('p');
+	expect(spyNotifyPeers).toHaveBeenCalled();
+});

--- a/__tests__/unit-tests/middlewares/lockMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/lockMiddleware.test.ts
@@ -1,0 +1,162 @@
+import { Next } from 'edumeet-common';
+import { userRoles } from '../../../src/common/authorization';
+import { MiddlewareOptions } from '../../../src/common/types';
+import { createLockMiddleware } from '../../../src/middlewares/lockMiddleware';
+import { PeerContext } from '../../../src/Peer';
+import Room from '../../../src/Room';
+
+const SESSION_ID = 'sessionId';
+const next = jest.fn as unknown as Next;
+
+test('Should not handle unrelated message', async () => {
+	const room = {
+		sessionId: SESSION_ID,
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLockMiddleware(options);
+
+	const context = {
+		message: {
+			method: 'non-existing-method',
+			data: {
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should not handle wrong session', async () => {
+	const room = {
+		sessionId: SESSION_ID,
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLockMiddleware(options);
+
+	const context = {
+		message: {
+			data: {
+				sessionId: 'wrong id',
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('lockRoom() - Should throw on not authorized', async () => {
+	const room = {
+		sessionId: SESSION_ID,
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLockMiddleware(options);
+	const peer = {
+		roles: []
+	};
+
+	const context = {
+		peer,
+		message: {
+			method: 'lockRoom',
+			data: {
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('lockRoom() - Should lock room on happy path', async () => {
+	const spyNotifyPeers = jest.fn();
+	const room = {
+		sessionId: SESSION_ID,
+		notifyPeers: spyNotifyPeers,
+		locked: false
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLockMiddleware(options);
+	const peer = {
+		roles: [ userRoles.NORMAL ]
+	};
+
+	const context = {
+		peer,
+		message: {
+			method: 'lockRoom',
+			data: {
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(spyNotifyPeers).toHaveBeenCalled();
+	expect(room.locked).toBeTruthy();
+});
+
+test('unlockRoom() - Should throw on not authorized', async () => {
+	const room = {
+		sessionId: SESSION_ID,
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLockMiddleware(options);
+	const peer = {
+		roles: []
+	};
+
+	const context = {
+		peer,
+		message: {
+			method: 'unlockRoom',
+			data: {
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test('unlockRoom() - Should unlock room on happy path', async () => {
+	const spyNotifyPeers = jest.fn();
+	const room = {
+		sessionId: SESSION_ID,
+		notifyPeers: spyNotifyPeers,
+		locked: true
+	} as unknown as Room;
+
+	const options = { room } as MiddlewareOptions;
+	const sut = createLockMiddleware(options);
+	const peer = {
+		roles: [ userRoles.NORMAL ]
+	};
+
+	const context = {
+		peer,
+		message: {
+			method: 'unlockRoom',
+			data: {
+				sessionId: SESSION_ID,
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(spyNotifyPeers).toHaveBeenCalled();
+	expect(room.locked).toBeFalsy();
+});

--- a/__tests__/unit-tests/middlewares/mediaMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/mediaMiddleware.test.ts
@@ -1,0 +1,401 @@
+import { Next } from 'edumeet-common';
+import { MiddlewareOptions } from '../../../src/common/types';
+import { createMediaMiddleware } from '../../../src/middlewares/mediaMiddleware';
+import { Peer, PeerContext } from '../../../src/Peer';
+import * as authorization from '../../../src/common/authorization';
+import { WebRtcTransport } from '../../../src/media/WebRtcTransport';
+import { Producer } from '../../../src/media/Producer';
+jest.spyOn(authorization, 'permittedProducer').mockImplementation(() => { return; });
+import ProducerMock from '../../../__mocks__/ProducerMock';
+import ConsumerMock from '../../../__mocks__/ConsumerMock';
+import * as consuming from '../../../src/common/consuming';
+import { Consumer } from '../../../src/media/Consumer';
+import { DataProducer } from '../../../src/media/DataProducer';
+
+const next = jest.fn() as Next;
+const SESSION_ID = 'sessionId';
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+test('Should not handle wrong session', async () => {
+	const room = {
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createMediaMiddleware(options);
+
+	const context = {
+		message: {
+			data: {
+				sessionId: 'wrong session'
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+    
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should not unrelated messages', async () => {
+	const room = {
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createMediaMiddleware(options);
+
+	const context = {
+		message: {
+			method: 'non-existing-method',
+			data: {
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test.each([
+	[ 'produce' ],
+	[ 'produceData' ]
+])('produce() - Should throw on missing transport', async (methodToTest: string) => {
+	const room = {
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createMediaMiddleware(options);
+
+	const appData = {};
+	const peer = {
+		transports: new Map<string, WebRtcTransport>()
+	} as Peer;
+    
+	const context = {
+		peer,
+		message: {
+			method: methodToTest,
+			data: {
+				appData,
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+
+});
+
+test('produce() - Should create producer', async () => {
+	const spyCreateConsumer = jest.spyOn(consuming, 'createConsumer').mockImplementation(async () => {
+		return;
+	});
+	const fakePeer = {};
+	const getPeers = jest.fn().mockImplementation(() => {
+		return [ fakePeer ];
+	});
+	const room = {
+		getPeers,
+		sessionId: SESSION_ID
+	};
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createMediaMiddleware(options);
+
+	const appData = {};
+	const peer = {
+		transports: new Map<string, WebRtcTransport>(),
+		producers: new Map<string, Producer>()
+	} as Peer;
+	const spySetProducer = jest.spyOn(peer.producers, 'set');
+	const producerMock = new ProducerMock();
+	const spyTransportProduce = jest.fn().mockImplementation(() => {
+		return producerMock;
+	});
+	const transport = {
+		id: 'id',
+		produce: spyTransportProduce
+	} as unknown as WebRtcTransport;
+
+	peer.transports.set(transport.id, transport);
+    
+	const context = {
+		peer,
+		response: {},
+		message: {
+			method: 'produce',
+			data: {
+				transportId: 'id',
+				appData,
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+
+	expect(getPeers).toHaveBeenCalled();
+	expect(spyTransportProduce).toHaveBeenCalled();
+	expect(context.handled).toBeTruthy();
+	expect(spySetProducer).toHaveBeenCalled();
+	expect(spyCreateConsumer).toHaveBeenCalled();
+	expect(context.response.id).toBe(producerMock.id);
+});
+
+test('produce() - Should handle events', async () => {
+	jest.spyOn(consuming, 'createDataConsumer').mockImplementation(async () => {
+		return;
+	});
+	const getPeers = jest.fn().mockImplementation(() => {
+		return [];
+	});
+	const room = {
+		getPeers,
+		sessionId: SESSION_ID
+	};
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createMediaMiddleware(options);
+
+	const appData = {};
+	const notify = jest.fn();
+	const peer = {
+		notify,
+		transports: new Map<string, WebRtcTransport>(),
+		producers: new Map<string, Producer>()
+	} as unknown as Peer;
+	const spyProducerDelete = jest.spyOn(peer.producers, 'delete');
+	const producerMock = new ProducerMock();
+	const spyTransportProduce = jest.fn().mockImplementation(() => {
+		return producerMock;
+	});
+	const transport = {
+		id: 'id',
+		produce: spyTransportProduce
+	} as unknown as WebRtcTransport;
+
+	peer.transports.set(transport.id, transport);
+    
+	const context = {
+		peer,
+		response: {},
+		message: {
+			method: 'produce',
+			data: {
+				transportId: 'id',
+				appData,
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+
+	producerMock.emit('score');
+	expect(notify.mock.calls[0][0].method).toBe('producerScore');
+
+	producerMock.emit('close');
+	expect(notify.mock.calls[1][0].method).toBe('producerClosed');
+	expect(spyProducerDelete).toHaveBeenCalled();
+});
+
+test('produceData() - Should create DataProducer', async () => {
+	const spyCreateDataConsumer = jest.spyOn(consuming, 'createDataConsumer').mockImplementation(async () => {
+		return;
+	});
+	const fakePeer = {};
+	const getPeers = jest.fn().mockImplementation(() => {
+		return [ fakePeer ];
+	});
+	const room = {
+		getPeers,
+		sessionId: SESSION_ID
+	};
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createMediaMiddleware(options);
+
+	const appData = {};
+	const peer = {
+		transports: new Map<string, WebRtcTransport>(),
+		dataProducers: new Map<string, DataProducer>()
+	} as Peer;
+	const spySetDataProducer = jest.spyOn(peer.dataProducers, 'set');
+	const producerMock = new ProducerMock();
+	const spyTransportProduceData = jest.fn().mockImplementation(() => {
+		return producerMock;
+	});
+	const transport = {
+		id: 'id',
+		produceData: spyTransportProduceData
+	} as unknown as WebRtcTransport;
+
+	peer.transports.set(transport.id, transport);
+    
+	const context = {
+		peer,
+		response: {},
+		message: {
+			method: 'produceData',
+			data: {
+				transportId: 'id',
+				appData,
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+
+	expect(getPeers).toHaveBeenCalled();
+	expect(spyTransportProduceData).toHaveBeenCalled();
+	expect(context.handled).toBeTruthy();
+	expect(spySetDataProducer).toHaveBeenCalled();
+	expect(spyCreateDataConsumer).toHaveBeenCalled();
+	expect(context.response.id).toBe(producerMock.id);
+});
+
+test('produceData() - Should handle events ', async () => {
+	jest.spyOn(consuming, 'createDataConsumer').mockImplementation(async () => {
+		return;
+	});
+	const fakePeer = {};
+	const getPeers = jest.fn().mockImplementation(() => {
+		return [ fakePeer ];
+	});
+	const room = {
+		getPeers,
+		sessionId: SESSION_ID
+	};
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createMediaMiddleware(options);
+
+	const appData = {};
+	const notify = jest.fn();
+	const peer = {
+		notify,
+		transports: new Map<string, WebRtcTransport>(),
+		dataProducers: new Map<string, DataProducer>()
+	} as unknown as Peer;
+	const producerMock = new ProducerMock();
+	const spyTransportProduceData = jest.fn().mockImplementation(() => {
+		return producerMock;
+	});
+	const transport = {
+		id: 'id',
+		produceData: spyTransportProduceData
+	} as unknown as WebRtcTransport;
+
+	peer.transports.set(transport.id, transport);
+    
+	const context = {
+		peer,
+		response: {},
+		message: {
+			method: 'produceData',
+			data: {
+				transportId: 'id',
+				appData,
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+
+	const spyDelete = jest.spyOn(peer.dataProducers, 'delete');
+
+	producerMock.emit('close');
+
+	expect(notify.mock.calls[0][0].method).toBe('dataProducerClosed');
+	expect(spyDelete).toHaveBeenCalled();
+});
+
+test.each([
+	[ 'requestConsumerKeyFrame', 'consumer' ],
+	[ 'setConsumerPriority', 'consumer' ],
+	[ 'setConsumerPreferredLayers', 'consumer' ],
+	[ 'pauseConsumer', 'consumer' ],
+	[ 'resumeConsumer', 'consumer' ],
+	[ 'closeDataProducer', 'dataProducer' ],
+	[ 'closeProducer', 'producer' ],
+	[ 'pauseProducer', 'producer' ],
+	[ 'resumeProducer', 'producer' ],
+])('%s() - Should throw on missing %s', async (methodToTest:string) => {
+	const room = {
+		sessionId: SESSION_ID
+	};
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createMediaMiddleware(options);
+
+	const peer = {
+		transports: new Map<string, WebRtcTransport>(),
+		producers: new Map<string, Producer>(),
+		consumers: new Map<string, Consumer>(),
+		dataProducers: new Map<string, DataProducer>()
+	} as unknown as Peer;
+
+	const context = {
+		peer,
+		response: {},
+		message: {
+			method: methodToTest,
+			data: {
+				producerId: 'id',
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test.each([
+	[ 'requestConsumerKeyFrame', 'requestKeyFrame', 'consumer' ],
+	[ 'setConsumerPriority', 'setPriority', 'consumer' ],
+	[ 'setConsumerPreferredLayers', 'setPreferredLayers', 'consumer' ],
+	[ 'pauseConsumer', 'pause', 'consumer' ],
+	[ 'resumeConsumer', 'resume', 'consumer' ],
+	[ 'closeDataProducer', 'close', 'dataProducer' ],
+	[ 'closeProducer', 'close', 'producer' ],
+	[ 'pauseProducer', 'pause', 'producer' ],
+	[ 'resumeProducer', 'resume', 'producer' ],
+])('%s() - Should call %s on %s', async (methodToTest:string) => {
+	const room = {
+		sessionId: SESSION_ID
+	};
+	const options = { room } as unknown as MiddlewareOptions;
+	const sut = createMediaMiddleware(options);
+
+	const peer = {
+		transports: new Map<string, WebRtcTransport>(),
+		producers: new Map<string, Producer>(),
+		consumers: new Map<string, Consumer>(),
+		dataProducers: new Map<string, DataProducer>()
+	} as unknown as Peer;
+	const consumer = new ConsumerMock() as unknown as Consumer;
+	const producer = new ProducerMock() as unknown as Producer;
+
+	peer.consumers.set(consumer.id, consumer);
+	peer.producers.set(producer.id, producer);
+	peer.dataProducers.set(producer.id, producer as unknown as DataProducer);
+
+	const context = {
+		peer,
+		response: {},
+		message: {
+			method: methodToTest,
+			data: {
+				producerId: 'id',
+				dataProducerId: 'id',
+				consumerId: 'id',
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+});

--- a/__tests__/unit-tests/middlewares/moderatorMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/moderatorMiddleware.test.ts
@@ -1,0 +1,259 @@
+import { List, Next } from 'edumeet-common';
+import { MiddlewareOptions } from '../../../src/common/types';
+import { Peer, PeerContext } from '../../../src/Peer';
+import { createModeratorMiddleware } from '../../../src/middlewares/moderatorMiddleware';
+import { userRoles } from '../../../src/common/authorization';
+import Room from '../../../src/Room';
+
+const next = jest.fn() as Next;
+const SESSION_ID = 'sessionId';
+const NON_EXISTING_ROLE_ID = '90019023901293';
+
+afterEach(() => {
+	jest.clearAllMocks();
+});
+
+test('Should not handle wrong session', async () => {
+	const room = {
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createModeratorMiddleware(options);
+
+	const context = {
+		message: {
+			data: {
+				sessionId: 'wrong session'
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+    
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should not unrelated messages', async () => {
+	const room = {
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createModeratorMiddleware(options);
+
+	const context = {
+		message: {
+			method: 'non-existing-method',
+			data: {
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test.each([
+	[ 'moderator:giveRole' ],
+	[ 'moderator:removeRole' ],
+	[ 'moderator:clearChat' ],
+	[ 'moderator:clearFiles' ],
+	[ 'moderator:mute' ],
+	[ 'moderator:muteAll' ],
+	[ 'moderator:stopVideo' ],
+	[ 'moderator:stopAllVideo' ],
+	[ 'moderator:stopScreenSharing' ],
+	[ 'moderator:stopAllScreenSharing' ],
+	[ 'moderator:closeMeeting' ],
+	[ 'moderator:kickPeer' ],
+	[ 'moderator:lowerHand' ]
+])('Should throw on %s if peer is not a moderator', async (methodToTest) => {
+	const room = {
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createModeratorMiddleware(options);
+	const peer = {
+		roles: []
+	} as unknown as Peer;
+	const context = {
+		peer,
+		message: {
+			method: methodToTest,
+			data: {
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test.each([
+	[ 'moderator:giveRole' ],
+	[ 'moderator:removeRole' ],
+])('Should throw on non existing role on method %s', async (methodToTest) => {
+	const room = {
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createModeratorMiddleware(options);
+	const peer = {
+		roles: [ userRoles.NORMAL ]
+	} as unknown as Peer;
+	const context = {
+		peer,
+		message: {
+			method: methodToTest,
+			data: {
+				roleId: NON_EXISTING_ROLE_ID,
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test.each([
+	[ 'moderator:giveRole' ],
+	[ 'moderator:removeRole' ],
+])('Should throw on non-promotable role on method %s', async (methodToTest) => {
+	const room = {
+		sessionId: SESSION_ID
+	};
+	const options = { room } as MiddlewareOptions;
+	const sut = createModeratorMiddleware(options);
+	const peer = {
+		roles: [ userRoles.NORMAL ]
+	} as unknown as Peer;
+	const context = {
+		peer,
+		message: {
+			method: methodToTest,
+			data: {
+				roleId: userRoles.NORMAL.id,
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test.each([
+	// [ 'moderator:giveRole' ], only NORMAL can promote peer so can not test this
+	// [ 'moderator:removeRole' ], only NORMAL can promote peer so can not test this
+	[ 'moderator:mute' ],
+	[ 'moderator:stopVideo' ],
+	[ 'moderator:stopScreenSharing' ],
+	[ 'moderator:kickPeer' ],
+	[ 'moderator:lowerHand' ]
+])('Should throw on peer not found for %s', async (methodToTest) => {
+	const room = {
+		sessionId: SESSION_ID,
+		peers: List<Peer>()
+	} as unknown as Room;
+	const options = { room } as MiddlewareOptions;
+	const sut = createModeratorMiddleware(options);
+	const peer = {
+		roles: [ userRoles.NORMAL ]
+	} as unknown as Peer;
+	const context = {
+		peer,
+		message: {
+			method: methodToTest,
+			data: {
+				peerId: 'non existing',
+				roleId: userRoles.PRESENTER.id,
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await expect(sut(context, next)).rejects.toThrow();
+});
+
+test.each([
+	[ 'moderator:clearChat' ],
+	[ 'moderator:clearFiles' ],
+	[ 'moderator:mute' ],
+	[ 'moderator:muteAll' ],
+	[ 'moderator:stopVideo' ],
+	[ 'moderator:stopAllVideo' ],
+	[ 'moderator:stopScreenSharing' ],
+	[ 'moderator:stopAllScreenSharing' ],
+	[ 'moderator:closeMeeting' ],
+	[ 'moderator:kickPeer' ],
+	[ 'moderator:lowerHand' ]
+])('Should handle happy path for %s', async (methodToTest) => {
+	const notifyPeers = jest.fn();
+	const spyCloseRoom = jest.fn();
+	const room = {
+		notifyPeers,
+		sessionId: SESSION_ID,
+		peers: List<Peer>(),
+		close: spyCloseRoom
+	} as unknown as Room;
+	const notify = jest.fn();
+	const spyClosePeer = jest.fn();
+	const fakePeer = {
+		notify,
+		close: spyClosePeer
+	} as unknown as Peer;
+
+	room.peers.add(fakePeer);
+
+	const fileHistory = { length: 2 };
+	const chatHistory = { length: 2 };
+	const options = { room, fileHistory, chatHistory } as MiddlewareOptions;
+	const sut = createModeratorMiddleware(options);
+	const peer = {
+		roles: [ userRoles.NORMAL ]
+	} as unknown as Peer;
+	const context = {
+		peer,
+		message: {
+			method: methodToTest,
+			data: {
+				roleId: userRoles.NORMAL.id,
+				sessionId: SESSION_ID
+			}
+		}
+	} as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	if (methodToTest == 'moderator:stopVideo' ||
+        methodToTest == 'moderator:stopScreenSharing' || 
+        methodToTest == 'moderator:lowerHand') {
+		expect(notify.mock.calls[0][0].method).toBe(methodToTest);
+	}
+	if (methodToTest == 'moderator:clearFiles') {
+		expect(notifyPeers.mock.calls[0][0]).toBe(methodToTest);
+		expect(fileHistory.length).toBe(0);
+	}
+	if (methodToTest == 'moderator:clearChat') {
+		expect(notifyPeers.mock.calls[0][0]).toBe(methodToTest);
+		expect(chatHistory.length).toBe(0);
+	}
+	if (methodToTest == 'moderator:kickPeer') {
+		expect(notify.mock.calls[0][0].method).toBe('moderator:kick');
+		expect(spyClosePeer).toHaveBeenCalled();
+	}
+	if (methodToTest == 'moderator:muteAll') {
+		expect(notifyPeers.mock.calls[0][0]).toBe('moderator:mute');
+	}
+	if (methodToTest == 'moderator:stopAllScreenSharing') {
+		expect(notifyPeers.mock.calls[0][0]).toBe('moderator:stopScreenSharing');
+	}
+	if (methodToTest == 'moderator:muteAllVideo') {
+		expect(notifyPeers.mock.calls[0][0]).toBe('moderator:stopVideo');
+	}
+	if (methodToTest == 'moderator:closeMeeting') {
+		expect(notifyPeers.mock.calls[0][0]).toBe('moderator:kick');
+		expect(spyCloseRoom).toHaveBeenCalled();
+	}
+});

--- a/__tests__/unit-tests/middlewares/peerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/peerMiddleware.test.ts
@@ -1,0 +1,124 @@
+import { createPeerMiddleware } from '../../../src/middlewares/peerMiddleware';
+import Room from '../../../src/Room';
+import { MiddlewareOptions } from '../../../src/common/types';
+import { PeerContext } from '../../../src/Peer';
+
+const next = jest.fn();
+
+test('Should not handle messages if room has parent', async () => {
+	const room = {
+		parent: {}
+	} as unknown as Room;
+	const options = { room } as MiddlewareOptions;
+	const sut = createPeerMiddleware(options);
+
+	const context = {
+		handled: false,
+		message: {
+			data: {
+			}
+		}
+	} as PeerContext; 
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should not handle unrelated messages', async () => {
+	const room = {} as unknown as Room;
+	const options = { room } as MiddlewareOptions;
+	const sut = createPeerMiddleware(options);
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'non-existing-method'
+		}
+	} as PeerContext; 
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('changeDisplayName() - Room should notify peers', async () => {
+	const notifyPeers = jest.fn();
+	const room = {
+		notifyPeers
+	} as unknown as Room;
+	const options = { room } as MiddlewareOptions;
+	const sut = createPeerMiddleware(options);
+
+	const peer = {};
+	const context = {
+		peer,
+		handled: false,
+		message: {
+			method: 'changeDisplayName',
+			data: {
+				displayName: 'n'
+			}
+		}
+	} as PeerContext; 
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(notifyPeers).toHaveBeenCalled();
+	expect(context.peer.displayName).toBe('n');
+});
+
+test('changePicture() - Room should notify peers', async () => {
+	const notifyPeers = jest.fn();
+	const room = {
+		notifyPeers
+	} as unknown as Room;
+	const options = { room } as MiddlewareOptions;
+	const sut = createPeerMiddleware(options);
+
+	const peer = {};
+	const context = {
+		peer,
+		handled: false,
+		message: {
+			method: 'changePicture',
+			data: {
+				picture: 'p'
+			}
+		}
+	} as PeerContext; 
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(notifyPeers).toHaveBeenCalled();
+	expect(context.peer.picture).toBe('p');
+});
+
+test('raisedHand() - Room should notify peers', async () => {
+	const notifyPeers = jest.fn();
+	const room = {
+		notifyPeers
+	} as unknown as Room;
+	const options = { room } as MiddlewareOptions;
+	const sut = createPeerMiddleware(options);
+
+	const peer = {};
+	const context = {
+		peer,
+		handled: false,
+		message: {
+			method: 'raisedHand',
+			data: {
+				raisedHand: true
+			}
+		}
+	} as PeerContext; 
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(notifyPeers).toHaveBeenCalled();
+	expect(context.peer.raisedHand).toBe(true);
+});

--- a/__tests__/unit-tests/middlewares/pipeConsumerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/pipeConsumerMiddleware.test.ts
@@ -1,0 +1,116 @@
+import { Next } from 'edumeet-common';
+import { PipeConsumer } from '../../../src/media/PipeConsumer';
+import { createPipeConsumerMiddleware } from '../../../src/middlewares/pipeConsumerMiddleware';
+import { PeerContext } from '../../../src/Peer';
+
+const ID = 'id';
+const next = jest.fn as unknown as Next;
+
+test('Should not handle unrelated message', async () => {
+	const pipeConsumer = {
+		id: ID,
+		router: {
+			id: ID
+		}
+	} as unknown as PipeConsumer;
+
+	const sut = createPipeConsumerMiddleware({ pipeConsumer });
+
+	const context = {
+		message: {
+			method: 'non-existing-method',
+			data: {
+				routerId: ID,
+				pipeConsumerId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('pipeConsumerClosed() - Should close pipeConsumer', async () => {
+	const close = jest.fn();
+	const pipeConsumer = {
+		id: ID,
+		router: {
+			id: ID
+		},
+		close
+	} as unknown as PipeConsumer;
+
+	const sut = createPipeConsumerMiddleware({ pipeConsumer });
+
+	const context = {
+		message: {
+			method: 'pipeConsumerClosed',
+			data: {
+				routerId: ID,
+				pipeConsumerId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(close).toHaveBeenCalled();
+});
+
+test('pipeConsumerPaused() - Should pause pipeConsumer', async () => {
+	const setProducerPaused = jest.fn();
+	const pipeConsumer = {
+		id: ID,
+		router: {
+			id: ID
+		},
+		setProducerPaused
+	} as unknown as PipeConsumer;
+
+	const sut = createPipeConsumerMiddleware({ pipeConsumer });
+
+	const context = {
+		message: {
+			method: 'pipeConsumerPaused',
+			data: {
+				routerId: ID,
+				pipeConsumerId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(setProducerPaused).toHaveBeenCalled();
+});
+
+test('pipeConsumerResumed() - Should pause pipeConsumer', async () => {
+	const setProducerResumed = jest.fn();
+	const pipeConsumer = {
+		id: ID,
+		router: {
+			id: ID
+		},
+		setProducerResumed
+	} as unknown as PipeConsumer;
+
+	const sut = createPipeConsumerMiddleware({ pipeConsumer });
+
+	const context = {
+		message: {
+			method: 'pipeConsumerResumed',
+			data: {
+				routerId: ID,
+				pipeConsumerId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(setProducerResumed).toHaveBeenCalled();
+});

--- a/__tests__/unit-tests/middlewares/pipeDataConsumerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/pipeDataConsumerMiddleware.test.ts
@@ -1,0 +1,60 @@
+import { Next } from 'edumeet-common';
+import { PipeDataConsumer } from '../../../src/media/PipeDataConsumer';
+import { createPipeDataConsumerMiddleware } from '../../../src/middlewares/pipeDataConsumerMiddleware';
+import { PeerContext } from '../../../src/Peer';
+
+const ID = 'id';
+const next = jest.fn as unknown as Next;
+
+test('Should not handle unrelated message', async () => {
+	const pipeDataConsumer = {
+		id: ID,
+		router: {
+			id: ID
+		}
+	} as unknown as PipeDataConsumer;
+
+	const sut = createPipeDataConsumerMiddleware({ pipeDataConsumer });
+
+	const context = {
+		message: {
+			method: 'non-existing-method',
+			data: {
+				routerId: ID,
+				pipeDataConsumerId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('pipeDataConsumerClosed() - Should close pipeDataConsumer', async () => {
+	const close = jest.fn();
+	const pipeDataConsumer = {
+		id: ID,
+		router: {
+			id: ID
+		},
+		close
+	} as unknown as PipeDataConsumer;
+
+	const sut = createPipeDataConsumerMiddleware({ pipeDataConsumer });
+
+	const context = {
+		message: {
+			method: 'pipeDataConsumerClosed',
+			data: {
+				routerId: ID,
+				pipeDataConsumerId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(close).toHaveBeenCalled();
+});

--- a/__tests__/unit-tests/middlewares/pipeDataProducerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/pipeDataProducerMiddleware.test.ts
@@ -1,0 +1,60 @@
+import { Next } from 'edumeet-common';
+import { PipeDataProducer } from '../../../src/media/PipeDataProducer';
+import { createPipeDataProducerMiddleware } from '../../../src/middlewares/pipeDataProducerMiddleware';
+import { PeerContext } from '../../../src/Peer';
+
+const ID = 'id';
+const next = jest.fn as unknown as Next;
+
+test('Should not handle unrelated message', async () => {
+	const pipeDataProducer = {
+		id: ID,
+		router: {
+			id: ID
+		}
+	} as unknown as PipeDataProducer;
+
+	const sut = createPipeDataProducerMiddleware({ pipeDataProducer });
+
+	const context = {
+		message: {
+			method: 'non-existing-method',
+			data: {
+				routerId: ID,
+				pipeDataProducerId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('pipeDataProducerClosed() - Should close pipeDataProducer', async () => {
+	const close = jest.fn();
+	const pipeDataProducer = {
+		id: ID,
+		router: {
+			id: ID
+		},
+		close
+	} as unknown as PipeDataProducer;
+
+	const sut = createPipeDataProducerMiddleware({ pipeDataProducer });
+
+	const context = {
+		message: {
+			method: 'pipeDataProducerClosed',
+			data: {
+				routerId: ID,
+				pipeDataProducerId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(close).toHaveBeenCalled();
+});

--- a/__tests__/unit-tests/middlewares/pipeProducerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/pipeProducerMiddleware.test.ts
@@ -1,0 +1,61 @@
+import { Next } from 'edumeet-common';
+import { PipeDataProducer } from '../../../src/media/PipeDataProducer';
+import { PipeProducer } from '../../../src/media/PipeProducer';
+import { createPipeProducerMiddleware } from '../../../src/middlewares/pipeProducerMiddleware';
+import { PeerContext } from '../../../src/Peer';
+
+const ID = 'id';
+const next = jest.fn as unknown as Next;
+
+test('Should not handle unrelated message', async () => {
+	const pipeProducer = {
+		id: ID,
+		router: {
+			id: ID
+		}
+	} as unknown as PipeProducer;
+
+	const sut = createPipeProducerMiddleware({ pipeProducer });
+
+	const context = {
+		message: {
+			method: 'non-existing-method',
+			data: {
+				routerId: ID,
+				pipeProducerId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('pipeDataProducerClosed() - Should close pipeDataProducer', async () => {
+	const close = jest.fn();
+	const pipeProducer = {
+		id: ID,
+		router: {
+			id: ID
+		},
+		close
+	} as unknown as PipeProducer;
+
+	const sut = createPipeProducerMiddleware({ pipeProducer });
+
+	const context = {
+		message: {
+			method: 'pipeProducerClosed',
+			data: {
+				routerId: ID,
+				pipeProducerId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(close).toHaveBeenCalled();
+});

--- a/__tests__/unit-tests/middlewares/pipeTransportMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/pipeTransportMiddleware.test.ts
@@ -1,28 +1,27 @@
 import { Next } from 'edumeet-common';
-import { PipeDataProducer } from '../../../src/media/PipeDataProducer';
-import { PipeProducer } from '../../../src/media/PipeProducer';
-import { createPipeProducerMiddleware } from '../../../src/middlewares/pipeProducerMiddleware';
+import { PipeTransport } from '../../../src/media/PipeTransport';
+import { createPipeTransportMiddleware } from '../../../src/middlewares/pipeTransportMiddleware';
 import { PeerContext } from '../../../src/Peer';
 
 const ID = 'id';
 const next = jest.fn as unknown as Next;
 
 test('Should not handle unrelated message', async () => {
-	const pipeProducer = {
+	const pipeTransport = {
 		id: ID,
 		router: {
 			id: ID
 		}
-	} as unknown as PipeProducer;
+	} as unknown as PipeTransport;
 
-	const sut = createPipeProducerMiddleware({ pipeProducer });
+	const sut = createPipeTransportMiddleware({ pipeTransport });
 
 	const context = {
 		message: {
 			method: 'non-existing-method',
 			data: {
 				routerId: ID,
-				pipeProducerId: ID
+				pipeTransportId: ID
 			}
 		}
 	} as unknown as PeerContext;
@@ -32,24 +31,24 @@ test('Should not handle unrelated message', async () => {
 	expect(context.handled).toBeFalsy();
 });
 
-test('pipeProducerClosed() - Should close pipeProducer', async () => {
+test('pipeTransportClosed() - Should close pipeTransport', async () => {
 	const close = jest.fn();
-	const pipeProducer = {
+	const pipeTransport = {
 		id: ID,
 		router: {
 			id: ID
 		},
 		close
-	} as unknown as PipeProducer;
+	} as unknown as PipeTransport;
 
-	const sut = createPipeProducerMiddleware({ pipeProducer });
+	const sut = createPipeTransportMiddleware({ pipeTransport });
 
 	const context = {
 		message: {
-			method: 'pipeProducerClosed',
+			method: 'pipeTransportClosed',
 			data: {
 				routerId: ID,
-				pipeProducerId: ID
+				pipeTransportId: ID
 			}
 		}
 	} as unknown as PeerContext;

--- a/__tests__/unit-tests/middlewares/producerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/producerMiddleware.test.ts
@@ -1,0 +1,115 @@
+import { Producer } from '../../../src/media/Producer';
+import { MediaNodeConnectionContext } from '../../../src/media/MediaNodeConnection';
+import { createProducerMiddleware } from '../../../src/middlewares/producerMiddleware';
+
+const next = jest.fn();
+
+test.each([
+	[ 'id', 'id', 'id', 'wrong', false ],
+	[ 'id', 'id', 'wrong', 'id', false ],
+	[ 'id', 'wrong', 'id', 'id', false ],
+	[ 'wrong', 'id', 'id', 'id', false ],
+	[ 'id', 'id', 'id', 'id', true ]
+])('Should not handle messages for wrong producer or router', async (routerId, routerIdInMessage, dataProducerId, dataProducerIdInMessage, wasHandled) => {
+	const producer = {
+		id: dataProducerId,
+		router: {
+			id: routerId
+		},
+		close: jest.fn()
+	} as unknown as Producer;
+	const sut = createProducerMiddleware({ producer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'producerClosed',
+			data: {
+				routerId: routerIdInMessage,
+				producerId: dataProducerIdInMessage
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBe(wasHandled);
+});
+
+test('Should not handle unrelated methods', async () => {
+	const producer = {
+		id: 'id',
+		router: {
+			id: 'id'
+		},
+	} as unknown as Producer;
+	const sut = createProducerMiddleware({ producer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'non-existing-method',
+			data: {
+				routerId: 'id',
+				producerId: 'id'
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeFalsy();
+});
+
+test('Should close producer', async () => {
+	const spy = jest.fn();
+	const producer = {
+		id: 'id',
+		router: {
+			id: 'id'
+		},
+		close: spy
+	} as unknown as Producer;
+	const sut = createProducerMiddleware({ producer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'producerClosed',
+			data: {
+				routerId: 'id',
+				producerId: 'id'
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeTruthy();
+	expect(spy).toHaveBeenCalled();
+});
+
+test('Should set score', async () => {
+	const spy = jest.fn();
+	const producer = {
+		id: 'id',
+		router: {
+			id: 'id'
+		},
+		setScore: spy
+	} as unknown as Producer;
+	const sut = createProducerMiddleware({ producer });
+
+	const context = {
+		handled: false,
+		message: {
+			method: 'producerScore',
+			data: {
+				score: 'score',
+				routerId: 'id',
+				producerId: 'id'
+			}
+		}
+	} as MediaNodeConnectionContext;
+
+	await sut(context, next);
+	expect(context.handled).toBeTruthy();
+	expect(spy).toHaveBeenCalledWith('score');
+});

--- a/__tests__/unit-tests/middlewares/routerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/routerMiddleware.test.ts
@@ -1,28 +1,26 @@
 import { Next } from 'edumeet-common';
-import { PipeDataProducer } from '../../../src/media/PipeDataProducer';
-import { PipeProducer } from '../../../src/media/PipeProducer';
-import { createPipeProducerMiddleware } from '../../../src/middlewares/pipeProducerMiddleware';
+import { Router } from '../../../src/media/Router';
+import { createRouterMiddleware } from '../../../src/middlewares/routerMiddleware';
 import { PeerContext } from '../../../src/Peer';
 
 const ID = 'id';
 const next = jest.fn as unknown as Next;
 
 test('Should not handle unrelated message', async () => {
-	const pipeProducer = {
+	const router = {
 		id: ID,
 		router: {
 			id: ID
 		}
-	} as unknown as PipeProducer;
+	} as unknown as Router; 
 
-	const sut = createPipeProducerMiddleware({ pipeProducer });
+	const sut = createRouterMiddleware({ router });
 
 	const context = {
 		message: {
 			method: 'non-existing-method',
 			data: {
 				routerId: ID,
-				pipeProducerId: ID
 			}
 		}
 	} as unknown as PeerContext;
@@ -32,24 +30,23 @@ test('Should not handle unrelated message', async () => {
 	expect(context.handled).toBeFalsy();
 });
 
-test('pipeProducerClosed() - Should close pipeProducer', async () => {
+test('routerClosed() - Should close router', async () => {
 	const close = jest.fn();
-	const pipeProducer = {
+	const router = {
 		id: ID,
 		router: {
 			id: ID
 		},
 		close
-	} as unknown as PipeProducer;
+	} as unknown as Router; 
 
-	const sut = createPipeProducerMiddleware({ pipeProducer });
+	const sut = createRouterMiddleware({ router });
 
 	const context = {
 		message: {
-			method: 'pipeProducerClosed',
+			method: 'routerClosed',
 			data: {
 				routerId: ID,
-				pipeProducerId: ID
 			}
 		}
 	} as unknown as PeerContext;

--- a/__tests__/unit-tests/middlewares/webRtcTransportMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/webRtcTransportMiddleware.test.ts
@@ -1,0 +1,60 @@
+import { Next } from 'edumeet-common';
+import { WebRtcTransport } from '../../../src/media/WebRtcTransport';
+import { createWebRtcTransportMiddleware } from '../../../src/middlewares/webRtcTransportMiddleware';
+import { PeerContext } from '../../../src/Peer';
+
+const ID = 'id';
+const next = jest.fn as unknown as Next;
+
+test('Should not handle unrelated message', async () => {
+	const webRtcTransport = {
+		id: ID,
+		router: {
+			id: ID
+		}
+	} as unknown as WebRtcTransport;
+
+	const sut = createWebRtcTransportMiddleware({ webRtcTransport });
+
+	const context = {
+		message: {
+			method: 'non-existing-method',
+			data: {
+				routerId: ID,
+				transportId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeFalsy();
+});
+
+test('webRtcTransportClosed() - Should close webRtcTransport', async () => {
+	const close = jest.fn();
+	const webRtcTransport = {
+		id: ID,
+		router: {
+			id: ID
+		},
+		close
+	} as unknown as WebRtcTransport;
+
+	const sut = createWebRtcTransportMiddleware({ webRtcTransport });
+
+	const context = {
+		message: {
+			method: 'webRtcTransportClosed',
+			data: {
+				routerId: ID,
+				transportId: ID
+			}
+		}
+	} as unknown as PeerContext;
+
+	await sut(context, next);
+
+	expect(context.handled).toBeTruthy();
+	expect(close).toHaveBeenCalled();
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,16 @@
+const { defaults: tsjPreset } = require('ts-jest/presets');
+
+/** @returns {Promise<import('jest').Config>} */
+
+module.exports = async () => {
+	return {
+		verbose: true,
+		modulePathIgnorePatterns: [ '<rootDir>/dist' ],
+		transform: {
+			...tsjPreset.transform,
+			'\\.[jt]s$': [
+				'ts-jest', { tsconfig: '<rootDir>/src/tsconfig.json' }
+			]
+		}
+	};
+};

--- a/package.json
+++ b/package.json
@@ -2,14 +2,15 @@
 	"name": "edumeet-room-server",
 	"version": "1.0.0",
 	"description": "Edumeet room server",
-	"main": "dist/server.js",
+	"main": "dist/src/server.js",
 	"author": "Håvar Aambø Fosstveit <havar@fosstveit.net>",
 	"license": "MIT",
 	"scripts": {
-		"build": "tsc",
-		"start": "tsc && node dist/src/server.js",
-		"prodstart": "node dist/src/server.js",
+		"build": "tsc --build src",
+		"start": "tsc --build src && node dist/src/server.js",
+		"prodstart": "node dist/server.js",
 		"lint": "eslint . --ext .ts",
+		"lint:fix": "eslint . --ext .ts --fix",
 		"connect": "node connect.js",
 		"test": "jest",
 		"test:coverage": "jest --coverage --coverageDirectory coverage",
@@ -41,8 +42,5 @@
 	"optionalDependencies": {
 		"bufferutil": "^4.0.7",
 		"utf-8-validate": "^5.0.10"
-	},
-	"jest": {
-		"preset": "ts-jest"
 	}
 }

--- a/src/middlewares/breakoutMiddleware.ts
+++ b/src/middlewares/breakoutMiddleware.ts
@@ -45,12 +45,12 @@ export const createBreakoutMiddleware = ({
 
 			case 'joinRoom': {
 				const { sessionId } = message.data;
-				const joinRoom = room.rooms.get(sessionId);
+				const roomToJoin = room.rooms.get(sessionId);
 
-				if (!joinRoom)
+				if (!roomToJoin)
 					throw new Error('room not found');
 
-				joinRoom.addPeer(peer);
+				roomToJoin.addPeer(peer);
 				context.handled = true;
 
 				break;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@tsconfig/node18/tsconfig.json",
+    "compilerOptions": {
+		"experimentalDecorators": true,
+		"resolveJsonModule": true,
+        "outDir": "../dist"
+    },
+    "include": ["**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
-	"extends": "@tsconfig/node18/tsconfig.json",
-	"compilerOptions": {
-		"experimentalDecorators": true,
-		"outDir": "dist",
-		"resolveJsonModule": true,
-		"esModuleInterop": true,
-	},
-	"include": ["src", "__tests__"],
-	"exclude": ["node_modules", "connect.js"]
+	"references": [
+		{"path": "./src"},
+		{"path": "./__tests__"}
+	],
+	"files": [],
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
 	"references": [
 		{"path": "./src"},
 		{"path": "./__tests__"}
+		{"path": "./__mocks__"}
 	],
 	"files": [],
 }


### PR DESCRIPTION
Will change typescript config to use projects.
That way we do not build `/__tests__` and `/__mocks__`, only `/src` and whatever is imported from there.

Add good unit-test coverage of middleware modules.

![image](https://user-images.githubusercontent.com/66301426/214767694-648d560e-91eb-42dc-bd6a-d35cc4cfaaed.png)
