### PR TITLE
refactor: due to changes in edumeet-common

### DIFF
--- a/__tests__/unit-tests/middlewares/lobbyPeerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/lobbyPeerMiddleware.test.ts
@@ -1,6 +1,5 @@
 import { Next } from 'edumeet-common';
 import { MiddlewareOptions } from '../../../src/common/types';
-import { createLobbyMiddleware } from '../../../src/middlewares/lobbyMiddleware';
 import { createLobbyPeerMiddleware } from '../../../src/middlewares/lobbyPeerMiddleware';
 import { PeerContext } from '../../../src/Peer';
 import Room from '../../../src/Room';

--- a/__tests__/unit-tests/middlewares/pipeProducerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/pipeProducerMiddleware.test.ts
@@ -1,5 +1,4 @@
 import { Next } from 'edumeet-common';
-import { PipeDataProducer } from '../../../src/media/PipeDataProducer';
 import { PipeProducer } from '../../../src/media/PipeProducer';
 import { createPipeProducerMiddleware } from '../../../src/middlewares/pipeProducerMiddleware';
 import { PeerContext } from '../../../src/Peer';

--- a/src/common/authorization.ts
+++ b/src/common/authorization.ts
@@ -2,6 +2,7 @@ import { Peer } from '../Peer';
 import Room from '../Room';
 import { Role } from './types';
 import { MediaSourceType } from 'edumeet-common';
+type MediaSourceType = typeof MediaSourceType[keyof typeof MediaSourceType];
 
 export const userRoles: Record<string, Role> = {
 	// These can be changed, id must be unique.

--- a/src/media/Consumer.ts
+++ b/src/media/Consumer.ts
@@ -2,9 +2,10 @@ import EventEmitter from 'events';
 import { MediaNodeConnection, MediaNodeConnectionContext } from './MediaNodeConnection';
 import { Router } from './Router';
 import { createConsumerMiddleware } from '../middlewares/consumerMiddleware';
-import { MediaKind, RtpParameters } from 'mediasoup-client/lib/RtpParameters';
+import { RtpParameters } from 'mediasoup-client/lib/RtpParameters';
 import { ConsumerLayers, ConsumerScore } from '../common/types';
-import { Logger, Middleware, skipIfClosed } from 'edumeet-common';
+import { Logger, Middleware, skipIfClosed, MediaKind } from 'edumeet-common';
+type MediaKind = typeof MediaKind[keyof typeof MediaKind];
 
 const logger = new Logger('Consumer');
 

--- a/src/media/PipeConsumer.ts
+++ b/src/media/PipeConsumer.ts
@@ -5,6 +5,7 @@ import { createPipeConsumerMiddleware } from '../middlewares/pipeConsumerMiddlew
 import { RtpParameters } from 'mediasoup-client/lib/RtpParameters';
 import { Logger, Middleware, skipIfClosed } from 'edumeet-common';
 import { MediaKind } from 'edumeet-common';
+type MediaKind = typeof MediaKind[keyof typeof MediaKind];
 
 const logger = new Logger('PipeConsumer');
 

--- a/src/media/PipeProducer.ts
+++ b/src/media/PipeProducer.ts
@@ -3,8 +3,8 @@ import { MediaNodeConnection, MediaNodeConnectionContext } from './MediaNodeConn
 import { Router } from './Router';
 import { createPipeProducerMiddleware } from '../middlewares/pipeProducerMiddleware';
 import { RtpParameters } from 'mediasoup-client/lib/RtpParameters';
-import { Logger, Middleware, skipIfClosed } from 'edumeet-common';
-import { MediaKind } from 'edumeet-common';
+import { Logger, Middleware, skipIfClosed, MediaKind } from 'edumeet-common';
+type MediaKind = typeof MediaKind[keyof typeof MediaKind];
 
 const logger = new Logger('PipeProducer');
 

--- a/src/media/PipeTransport.ts
+++ b/src/media/PipeTransport.ts
@@ -11,6 +11,7 @@ import { SctpStreamParameters } from 'mediasoup-client/lib/SctpParameters';
 import { PipeDataProducer, PipeDataProducerOptions } from './PipeDataProducer';
 import { PipeDataConsumer, PipeDataConsumerOptions } from './PipeDataConsumer';
 import { MediaKind } from 'edumeet-common';
+type MediaKind = typeof MediaKind[keyof typeof MediaKind];
 
 const logger = new Logger('PipeTransport');
 

--- a/src/media/Producer.ts
+++ b/src/media/Producer.ts
@@ -6,6 +6,7 @@ import { RtpParameters } from 'mediasoup-client/lib/RtpParameters';
 import { ProducerScore } from '../common/types';
 import { Logger, Middleware, skipIfClosed } from 'edumeet-common';
 import { MediaKind } from 'edumeet-common';
+type MediaKind = typeof MediaKind[keyof typeof MediaKind];
 
 const logger = new Logger('Producer');
 

--- a/src/media/WebRtcTransport.ts
+++ b/src/media/WebRtcTransport.ts
@@ -11,6 +11,7 @@ import { Logger, Middleware, skipIfClosed } from 'edumeet-common';
 import { DataProducer, DataProducerOptions } from './DataProducer';
 import { DataConsumer, DataConsumerOptions } from './DataConsumer';
 import { MediaKind } from 'edumeet-common';
+type MediaKind = typeof MediaKind[keyof typeof MediaKind];
 
 const logger = new Logger('WebRtcTransport');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,8 +1370,8 @@ ecdsa-sig-formatter@1.0.11:
     safe-buffer "^5.0.1"
 
 edumeet-common@edumeet/edumeet-common:
-  version "0.2.3"
-  resolved "https://codeload.github.com/edumeet/edumeet-common/tar.gz/26b0a5f8df48c44cfb53c4ab0ef95dd96f81b4bb"
+  version "0.2.4"
+  resolved "https://codeload.github.com/edumeet/edumeet-common/tar.gz/fc50478dcef2fd5bfcc2950ebecf54e2614c83db"
   dependencies:
     debug "^4.3.4"
     socket.io-client "^4.5.3"
@@ -1433,9 +1433,9 @@ engine.io-parser@~2.2.0:
     has-binary2 "~1.0.2"
 
 engine.io-parser@~5.0.3:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.4.tgz#0b13f704fa9271b3ec4f33112410d8f3f41d0fc0"
-  integrity sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.6.tgz#7811244af173e157295dec9b2718dfe42a64ef45"
+  integrity sha512-tjuoZDMAdEhVnSFleYPCtdL2GXwVTGtNjoeJd9IhIG3C1xs9uwxqRNEu5WpnDZCaozwVlK/nuQhpodhXSIMaxw==
 
 engine.io@~3.6.0:
   version "3.6.1"
@@ -3057,10 +3057,18 @@ socket.io-parser@~3.4.0:
     debug "~4.1.0"
     isarray "2.0.1"
 
-socket.io-parser@~4.2.0, socket.io-parser@~4.2.1:
+socket.io-parser@~4.2.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.1.tgz#01c96efa11ded938dcb21cbe590c26af5eff65e5"
   integrity sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
+
+socket.io-parser@~4.2.1:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.2.tgz#1dd384019e25b7a3d374877f492ab34f2ad0d206"
+  integrity sha512-DJtziuKypFkMMHCm2uIshOYC7QaylbtzQwiMYDuCKy3OPkjLzu4B2vAhTlqipRHHzrI0NJeBAizTK7X+6m1jVw==
   dependencies:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"


### PR DESCRIPTION
After building `edumeet-common` properly with `yarn build`, `MediaKind` and `MediaSourceType` was transpiled in a way that they're no longer exported as values **and** types.

Thus, we need to define types locally when using them.

Not beautiful and not really my idea when wanting to use constants in `edumeet-common` rather than error prone strings.