### PR TITLE
upgrade edumeet-common dependency

### DIFF
--- a/__tests__/unit-tests/middlewares/lobbyPeerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/lobbyPeerMiddleware.test.ts
@@ -1,6 +1,5 @@
 import { Next } from 'edumeet-common';
 import { MiddlewareOptions } from '../../../src/common/types';
-import { createLobbyMiddleware } from '../../../src/middlewares/lobbyMiddleware';
 import { createLobbyPeerMiddleware } from '../../../src/middlewares/lobbyPeerMiddleware';
 import { PeerContext } from '../../../src/Peer';
 import Room from '../../../src/Room';

--- a/__tests__/unit-tests/middlewares/pipeProducerMiddleware.test.ts
+++ b/__tests__/unit-tests/middlewares/pipeProducerMiddleware.test.ts
@@ -1,5 +1,4 @@
 import { Next } from 'edumeet-common';
-import { PipeDataProducer } from '../../../src/media/PipeDataProducer';
 import { PipeProducer } from '../../../src/media/PipeProducer';
 import { createPipeProducerMiddleware } from '../../../src/middlewares/pipeProducerMiddleware';
 import { PeerContext } from '../../../src/Peer';

--- a/src/media/Consumer.ts
+++ b/src/media/Consumer.ts
@@ -2,9 +2,9 @@ import EventEmitter from 'events';
 import { MediaNodeConnection, MediaNodeConnectionContext } from './MediaNodeConnection';
 import { Router } from './Router';
 import { createConsumerMiddleware } from '../middlewares/consumerMiddleware';
-import { MediaKind, RtpParameters } from 'mediasoup-client/lib/RtpParameters';
+import { RtpParameters } from 'mediasoup-client/lib/RtpParameters';
 import { ConsumerLayers, ConsumerScore } from '../common/types';
-import { Logger, Middleware, skipIfClosed } from 'edumeet-common';
+import { Logger, Middleware, skipIfClosed, MediaKind } from 'edumeet-common';
 
 const logger = new Logger('Consumer');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,8 +1370,8 @@ ecdsa-sig-formatter@1.0.11:
     safe-buffer "^5.0.1"
 
 edumeet-common@edumeet/edumeet-common:
-  version "0.2.3"
-  resolved "https://codeload.github.com/edumeet/edumeet-common/tar.gz/26b0a5f8df48c44cfb53c4ab0ef95dd96f81b4bb"
+  version "0.2.5"
+  resolved "https://codeload.github.com/edumeet/edumeet-common/tar.gz/7780e1944b7eda4824f490e2bdca61dfe5722589"
   dependencies:
     debug "^4.3.4"
     socket.io-client "^4.5.3"


### PR DESCRIPTION
upgrade to edumeet-common 0.2.5 which have correct type exports for mediakind and mediasourcetype
remove unused imports in middleware tests