### PR TITLE
Start server in HTTP mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ It handles signaling to and from client and media node services.
 Make a file called `config.json` in the `/config` folder. An example configuration file with all properties set to default values can be found here:
 [config.example.json](config/config.example.json)
 
+Note that if you don't provide a value for `tls.cert` and `tls.key` the server will start in HTTP mode.
+
 ### Docker
 
 Running the service as a docker container.

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,12 +3,31 @@ process.title = 'edumeet-room-server';
 import config from '../config/config.json';
 import fs from 'fs';
 import https from 'https';
+import http from 'http';
 import ServerManager from './ServerManager';
 import { Server as IOServer } from 'socket.io';
 import { interactiveServer } from './interactiveServer';
 import { Logger } from 'edumeet-common';
 import MediaService from './MediaService';
 import { socketHandler } from './common/socketHandler';
+
+interface Config {
+	listenHost: string;
+	listenPort: string;
+	tls?: {
+		cert: string;
+		key: string;
+	};
+	mediaNodes?: Array<{
+		hostname: string;
+		port: number;
+		secret: string;
+		latitude: number;
+		longitude: number;
+	}>;
+}
+
+const actualConfig = config as Config;
 
 const logger = new Logger('Server');
 
@@ -19,27 +38,35 @@ const serverManager = new ServerManager({ mediaService });
 
 interactiveServer(serverManager);
 
-const httpsServer = https.createServer({
-	cert: fs.readFileSync(config.tls.cert),
-	key: fs.readFileSync(config.tls.key),
-	minVersion: 'TLSv1.2',
-	ciphers: [
-		'ECDHE-ECDSA-AES128-GCM-SHA256',
-		'ECDHE-RSA-AES128-GCM-SHA256',
-		'ECDHE-ECDSA-AES256-GCM-SHA384',
-		'ECDHE-RSA-AES256-GCM-SHA384',
-		'ECDHE-ECDSA-CHACHA20-POLY1305',
-		'ECDHE-RSA-CHACHA20-POLY1305',
-		'DHE-RSA-AES128-GCM-SHA256',
-		'DHE-RSA-AES256-GCM-SHA384'
-	].join(':'),
-	honorCipherOrder: true
-});
+let webServer: http.Server | https.Server;
 
-httpsServer.listen({ port: config.listenPort, host: config.listenHost }, () =>
-	logger.debug('httpsServer.listen() [port: %s]', config.listenPort));
+if (actualConfig.tls?.cert && actualConfig.tls?.key) {
+	webServer = https.createServer({
+		cert: fs.readFileSync(actualConfig.tls.cert),
+		key: fs.readFileSync(actualConfig.tls.key),
+		minVersion: 'TLSv1.2',
+		ciphers: [
+			'ECDHE-ECDSA-AES128-GCM-SHA256',
+			'ECDHE-RSA-AES128-GCM-SHA256',
+			'ECDHE-ECDSA-AES256-GCM-SHA384',
+			'ECDHE-RSA-AES256-GCM-SHA384',
+			'ECDHE-ECDSA-CHACHA20-POLY1305',
+			'ECDHE-RSA-CHACHA20-POLY1305',
+			'DHE-RSA-AES128-GCM-SHA256',
+			'DHE-RSA-AES256-GCM-SHA384'
+		].join(':'),
+		honorCipherOrder: true
+	});
+} else {
+	logger.debug('No TLS certificate or key provided, using HTTP');
 
-const socketServer = new IOServer(httpsServer, {
+	webServer = http.createServer();
+}
+
+webServer.listen({ port: actualConfig.listenPort, host: actualConfig.listenHost }, () =>
+	logger.debug('webServer.listen() [port: %s]', actualConfig.listenPort));
+
+const socketServer = new IOServer(webServer, {
 	cors: { origin: '*' },
 	cookie: false
 });
@@ -50,7 +77,7 @@ const close = () => {
 	logger.debug('close()');
 
 	serverManager.close();
-	httpsServer.close();
+	webServer.close();
 
 	process.exit(0);
 };


### PR DESCRIPTION
If you want to start the server in HTTP mode, don't provide the tls key and cert in the config.