### PR TITLE
fix: filter on load in loadbalancer

### DIFF
--- a/__tests__/unit-tests/LoadBalancer.test.ts
+++ b/__tests__/unit-tests/LoadBalancer.test.ts
@@ -114,18 +114,12 @@ test('Should filter out candidates on load', () => {
 		forwardedFor: undefined
 	})
 	} as unknown as Peer;
-	const spyNearestNeighbors = jest.fn().mockReturnValue(
-		[ ]
+	const kdTree = new KDTree([ new KDPoint([ 50, 10 ], { mediaNode: mediaNode3 }) ]
 	);
-	const kdTree = {
-		nearestNeighbors: spyNearestNeighbors
-	} as unknown as KDTree;
-
-	const sut = new LoadBalancer({ kdTree, defaultClientPosition });
+	const sut = new LoadBalancer({ kdTree, defaultClientPosition, cpuLoadThreshold: 0.85 });
 	const candidates = sut.getCandidates(room, peer);
 
 	expect(spyGetActiveMediaNodes).toHaveBeenCalledTimes(1);
-	expect(spyNearestNeighbors).toHaveBeenCalledTimes(1);
 	expect(candidates.length).toBe(0);
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "edumeet-room-server",
-	"version": "1.1.0",
+	"version": "1.2.1",
 	"description": "Edumeet room server",
 	"main": "dist/src/server.js",
 	"author": "Håvar Aambø Fosstveit <havar@fosstveit.net>",

--- a/src/LoadBalancer.ts
+++ b/src/LoadBalancer.ts
@@ -55,7 +55,7 @@ export default class LoadBalancer {
 				(point) => {
 					const node = point.appData.mediaNode as unknown as MediaNode;
 					
-					return node.load < 85;
+					return node.load < this.cpuLoadThreshold;
 				}
 			);
 


### PR DESCRIPTION
This PR fixes a regression in LoadBalancer not caught by our tests.
It also adds a test to make sure it does not happen again.