### PR TITLE
Fix/getrouter hail mary

### DIFF
--- a/__tests__/integration-tests/LoadBalancing.test.ts
+++ b/__tests__/integration-tests/LoadBalancing.test.ts
@@ -10,24 +10,28 @@ const mockMediaService = {} as unknown as MediaService;
 const nodeClose1 = {
 	load: 0.2,
 	id: 'id1',
+	health: true,
 	kdPoint: new KDPoint([ 48.8543,	 2.3527 ])
 } as unknown as MediaNode;
 const kdPointClose1 = new KDPoint([ 48.8543,	 2.3527 ], { mediaNode: nodeClose1 });
 const nodeClose2 = {
 	load: 0.4,
 	id: 'id2',
+	health: true,
 	kdPoint: new KDPoint([ 48.8543,	 2.3527 ])
 } as unknown as MediaNode;
 const kdPointClose2 = new KDPoint([ 48.8543,	 2.3527 ], { mediaNode: nodeClose2 });
 const nodeClose3 = {
 	load: 0.1,
 	id: 'id3',
+	health: true,
 	kdPoint: new KDPoint([ 48.8543,	 2.3527 ])
 } as unknown as MediaNode;
 const kdPointClose3 = new KDPoint([ 48.8543,	 2.3527 ], { mediaNode: nodeClose3 });
 const nodeClose4 = {
 	load: 0.1,
 	id: 'id3',
+	health: true,
 	kdPoint: new KDPoint([ 48.8543,	 2.3527 ])
 
 } as unknown as MediaNode;
@@ -35,17 +39,20 @@ const kdPointClose4 = new KDPoint([ 48.8543,	 2.3527 ], { mediaNode: nodeClose4 
 const nodeClose5 = {
 	load: 0.1,
 	id: 'id3',
+	health: true,
 	kdPoint: new KDPoint([ 48.8543,	 2.3527 ])
 } as unknown as MediaNode;
 const kdPointClose5 = new KDPoint([ 48.8543,	 2.3527 ], { mediaNode: nodeClose5 });
 const nodeFarAway = {
 	load: 0.1,
 	id: 'id3',
+	health: true,
 	kdPoint: new KDPoint([ 16.8833,	 101.8833 ])
 } as unknown as MediaNode;
 const nodeHighLoad = {
 	load: 0.9,
 	id: 'id4',
+	health: true,
 	kdPoint: new KDPoint([ 48.8543,	 2.3527 ])
 } as unknown as MediaNode;
 const kdPointHighLoad = new KDPoint([ 48.8543, 2.3527 ], { mediaNode: nodeHighLoad });

--- a/__tests__/integration-tests/LoadBalancing.test.ts
+++ b/__tests__/integration-tests/LoadBalancing.test.ts
@@ -141,3 +141,34 @@ test('Should use load strategy', () => {
 	expect(candidates.length).toBe(1);
 	expect(candidates).not.toContain(kdPointHighLoad);
 });
+
+test('Should filter on media-node health', () => {
+	const unhealthyMediaNode = {
+		load: 0.2,
+		id: 'id1',
+		health: false,
+		kdPoint: new KDPoint([ 48.8543,	 2.3527 ])
+	} as unknown as MediaNode;
+	const kdPoint = new KDPoint([ 48.8543,	 2.3527 ], { mediaNode: unhealthyMediaNode });
+	const defaultClientPosition = new KDPoint([ 40, 40 ]);
+	
+	// KDTree will consider the unhealthy MediaNode and should filter it out.
+	const kdTree = new KDTree([ kdPoint ]);
+	const sut = new LoadBalancer({ kdTree, defaultClientPosition });
+	const peer = { getAddress: () => { return clientDirect; } } as unknown as Peer;
+	const activeRoom = new Room({
+		id: 'id',
+		name: 'name',
+		mediaService: mockMediaService
+	});
+
+	const router = { mediaNode: unhealthyMediaNode } as unknown as Router;
+
+	// This will make the MediaNode sticky candidate, which should be filtered out.
+	activeRoom.addRouter(router);
+
+	const candidates = sut.getCandidates(activeRoom, peer);
+
+	expect(candidates.length).toBe(0);
+	expect(candidates).not.toContain(kdPoint);
+});

--- a/__tests__/integration-tests/MediaNode-health.test.ts
+++ b/__tests__/integration-tests/MediaNode-health.test.ts
@@ -121,7 +121,7 @@ test('MediaService getRouter() should stop trying on successful candidate', asyn
 	});
 	const peer = new Peer({
 		id: 'id',
-		roomId: 'id'
+		sessionId: 'id'
 	});
 
 	await expect(sut.getRouter(room, peer)).resolves.not.toThrow();

--- a/__tests__/unit-tests/LoadBalancer.test.ts
+++ b/__tests__/unit-tests/LoadBalancer.test.ts
@@ -6,9 +6,9 @@ import Room from '../../src/Room';
 
 const kdPoint1 = new KDPoint([ 50, 10 ]);
 const kdPoint2= new KDPoint([ 50, 10 ]);
-const mediaNode1 = { id: 'id1', load: 0.2, kdPoint: kdPoint1 } as unknown as MediaNode;
-const mediaNode2 = { id: 'id2', load: 0.3, kdPoint: kdPoint2 } as unknown as MediaNode;
-const mediaNode3 = { id: 'id2', load: 0.9, kdPoint: kdPoint2 } as unknown as MediaNode;
+const mediaNode1 = { id: 'id1', load: 0.2, health: true, kdPoint: kdPoint1 } as unknown as MediaNode;
+const mediaNode2 = { id: 'id2', load: 0.3, health: true, kdPoint: kdPoint2 } as unknown as MediaNode;
+const mediaNode3 = { id: 'id2', load: 0.9, health: true, kdPoint: kdPoint2 } as unknown as MediaNode;
 const defaultClientPosition = new KDPoint([ 50, 10 ]);
 const clientAddress = '5.44.192.0';
 
@@ -44,7 +44,7 @@ test.each([
 	expect(candidates[1]).toBe(mediaNode2);
 });
 
-test('Should place sticky candidate first return array', () => {
+test('Should place sticky candidate first in return array', () => {
 	const spyGetActiveMediaNodes = jest.fn().mockReturnValue([ mediaNode2 ]);
 	const room = {
 		getActiveMediaNodes: spyGetActiveMediaNodes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "edumeet-room-server",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "Edumeet room server",
 	"main": "dist/src/server.js",
 	"author": "Håvar Aambø Fosstveit <havar@fosstveit.net>",

--- a/src/LoadBalancer.ts
+++ b/src/LoadBalancer.ts
@@ -41,7 +41,7 @@ export default class LoadBalancer {
 			logger.debug('getCandidates() [room.id: %s, peer.id: %s]', room.id, peer.id);
 			// Get sticky candidates
 			let candidates = room.getActiveMediaNodes()
-				.filter((m) => m.load < this.cpuLoadThreshold)
+				.filter((m) => m.health && m.load < this.cpuLoadThreshold)
 				.sort((a, b) => a.load - b.load);
 			const peerGeoPosition = this.getClientPosition(peer) ?? this.defaultClientPosition;
 

--- a/src/LoadBalancer.ts
+++ b/src/LoadBalancer.ts
@@ -48,14 +48,13 @@ export default class LoadBalancer {
 			candidates = this.filterOnGeoThreshold(candidates, peerGeoPosition);
 			
 			// Get additional candidates from KDTree
-			// TODO check health status, don't return unhealty candidates
 			const kdtreeCandidates = this.kdTree.nearestNeighbors(
 				peerGeoPosition,
 				5,
 				(point) => {
 					const node = point.appData.mediaNode as unknown as MediaNode;
 					
-					return node.load < this.cpuLoadThreshold;
+					return node.health && node.load < this.cpuLoadThreshold;
 				}
 			);
 


### PR DESCRIPTION
This PR will make `MediaService` consider all `MediaNode` instances as candidates before throwing an error.

When there are no valid sticky candidates, and the first batch of candidates from `KDTree` fail, we go to "hail mary" attempt mode. We keep asking `LoadBalancer` for candidates until we find one or run out of them.

We now filter out candidates (both sticky and `KDTree` origin) on health in `LoadBalancer` instead of `MediaService`.

I updated/added unit-tests and integration tests for validation.