### PR TITLE
feat/notify ignorebreakout

### DIFF
--- a/__tests__/unit-tests/Room.ts
+++ b/__tests__/unit-tests/Room.ts
@@ -5,6 +5,7 @@ import { Router } from '../../src/media/Router';
 import LoadBalancer from '../../src/LoadBalancer';
 import { Config } from '../../src/Config';
 import { KDTree } from 'edumeet-common';
+import { Peer } from '../../src/Peer';
 
 describe('Room', () => {
 	let room1: Room;
@@ -47,6 +48,46 @@ describe('Room', () => {
 		room1.close();
 		expect(room1.closed).toBe(true);
 		expect(spyEmit).toHaveBeenCalledTimes(1);
+	});
+
+	it('notifyPeers() should notify peers in breakout rooms by default', () => {
+		const peerOptions = {
+			id: 'id',
+		};
+
+		const p1 = new Peer({ ...peerOptions, sessionId: room1.sessionId });
+		const p2 = new Peer({ ...peerOptions, sessionId: 'breakout' });
+
+		room1.peers.add(p1);
+		room1.peers.add(p2);
+
+		const spy1 = jest.spyOn(p1, 'notify');
+		const spy2 = jest.spyOn(p2, 'notify');
+
+		room1.notifyPeers({ method: 'test', data: {} });
+
+		expect(spy1).toHaveBeenCalled();
+		expect(spy2).toHaveBeenCalled();
+	});
+	
+	it('notifyPeers() should be able to ignore peers in breakout rooms', () => {
+		const peerOptions = {
+			id: 'id',
+		};
+
+		const p1 = new Peer({ ...peerOptions, sessionId: room1.sessionId });
+		const p2 = new Peer({ ...peerOptions, sessionId: 'breakout' });
+
+		room1.peers.add(p1);
+		room1.peers.add(p2);
+
+		const spy1 = jest.spyOn(p1, 'notify');
+		const spy2 = jest.spyOn(p2, 'notify');
+
+		room1.notifyPeers({ method: 'test', data: {}, ignoreBreakout: true });
+
+		expect(spy1).toHaveBeenCalledTimes(1);
+		expect(spy2).not.toHaveBeenCalled();
 	});
 
 	describe('Router', () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "edumeet-room-server",
-	"version": "1.2.2",
+	"version": "1.3.0",
 	"description": "Edumeet room server",
 	"main": "dist/src/server.js",
 	"author": "Håvar Aambø Fosstveit <havar@fosstveit.net>",

--- a/src/BreakoutRoom.ts
+++ b/src/BreakoutRoom.ts
@@ -14,6 +14,12 @@ interface BreakoutRoomOptions {
 	parent: Room;
 }
 
+interface NotifyPeersOptions {
+	method: string,
+	data: unknown,
+	excludePeer?: Peer
+}
+
 export default class BreakoutRoom extends EventEmitter {
 	public name?: string;
 	public sessionId = randomUUID();
@@ -87,7 +93,7 @@ export default class BreakoutRoom extends EventEmitter {
 	}
 
 	@skipIfClosed
-	public notifyPeers(method: string, data: unknown, excludePeer?: Peer): void {
+	public notifyPeers({ method, data, excludePeer }: NotifyPeersOptions): void {
 		const peers = this.getPeers(excludePeer);
 
 		for (const peer of peers) {

--- a/src/middlewares/breakoutMiddleware.ts
+++ b/src/middlewares/breakoutMiddleware.ts
@@ -38,7 +38,10 @@ export const createBreakoutMiddleware = ({ room }: { room: Room; }): Middleware<
 
 				room.breakoutRooms.set(newBreakoutRoom.sessionId, newBreakoutRoom);
 				newBreakoutRoom.once('close', () => room.breakoutRooms.delete(newBreakoutRoom.sessionId));
-				room.notifyPeers('newBreakoutRoom', { name, roomSessionId: newBreakoutRoom.sessionId, creationTimestamp: newBreakoutRoom.creationTimestamp }, peer);
+				room.notifyPeers({
+					method: 'newBreakoutRoom',
+					data: { name, roomSessionId: newBreakoutRoom.sessionId, creationTimestamp: newBreakoutRoom.creationTimestamp },
+					excludePeer: peer });
 
 				response.sessionId = newBreakoutRoom.sessionId;
 				response.creationTimestamp = newBreakoutRoom.creationTimestamp;
@@ -77,7 +80,7 @@ export const createBreakoutMiddleware = ({ room }: { room: Room; }): Middleware<
 
 				roomToClose.getPeers().forEach((p) => changeRoom(room, p, true));
 				roomToClose.close();
-				room.notifyPeers('breakoutRoomClosed', { roomSessionId }, peer);
+				room.notifyPeers({ method: 'breakoutRoomClosed', data: { roomSessionId }, excludePeer: peer });
 
 				context.handled = true;
 
@@ -136,7 +139,10 @@ export const createBreakoutMiddleware = ({ room }: { room: Room; }): Middleware<
 		const roomToLeave = room.breakoutRooms.get(peer.sessionId);
 
 		roomToLeave?.removePeer(peer);
-		room.notifyPeers('changeSessionId', { peerId: peer.id, sessionId: roomToJoin.sessionId, oldSessionId: peer.sessionId }, peer);
+		room.notifyPeers({
+			method: 'changeSessionId',
+			data: { peerId: peer.id, sessionId: roomToJoin.sessionId, oldSessionId: peer.sessionId },
+			excludePeer: peer });
 		peer.closeProducers();
 
 		// This will trigger the consumers of peers not in the room to be closed

--- a/src/middlewares/chatMiddleware.ts
+++ b/src/middlewares/chatMiddleware.ts
@@ -39,10 +39,13 @@ export const createChatMiddleware = ({ room }: { room: Room | BreakoutRoom; }): 
 
 				room.chatHistory.push(chatMessage);
 
-				room.notifyPeers('chatMessage', {
-					peerId: peer.id,
-					chatMessage,
-				}, peer);
+				room.notifyPeers({ method: 'chatMessage',
+					data: {
+						peerId: peer.id,
+						chatMessage,
+					},
+					excludePeer: peer
+				});
 
 				context.handled = true;
 

--- a/src/middlewares/fileMiddleware.ts
+++ b/src/middlewares/fileMiddleware.ts
@@ -39,10 +39,12 @@ export const createFileMiddleware = ({ room }: { room: Room | BreakoutRoom; }): 
 
 				room.fileHistory.push(file);
 
-				room.notifyPeers('sendFile', {
-					peerId: peer.id,
-					file,
-				}, peer);
+				room.notifyPeers({ method: 'sendFile',
+					data: {
+						peerId: peer.id,
+						file,
+					},
+					excludePeer: peer });
 
 				context.handled = true;
 

--- a/src/middlewares/lobbyPeerMiddleware.ts
+++ b/src/middlewares/lobbyPeerMiddleware.ts
@@ -27,10 +27,12 @@ export const createLobbyPeerMiddleware = ({ room }: { room: Room; }): Middleware
 				peer.displayName = displayName;
 
 				// TODO: only send to PROMOTE_PEER peers
-				room.notifyPeers('lobby:changeDisplayName', {
-					peerId: peer.id,
-					displayName
-				}, peer);
+				room.notifyPeers({ method: 'lobby:changeDisplayName',
+					data: {
+						peerId: peer.id,
+						displayName
+					},
+					excludePeer: peer });
 
 				context.handled = true;
 
@@ -43,10 +45,12 @@ export const createLobbyPeerMiddleware = ({ room }: { room: Room; }): Middleware
 				peer.picture = picture;
 
 				// TODO: only send to PROMOTE_PEER peers
-				room.notifyPeers('lobby:changePicture', {
-					peerId: peer.id,
-					picture
-				}, peer);
+				room.notifyPeers({ method: 'lobby:changePicture',
+					data: {
+						peerId: peer.id,
+						picture
+					},
+					excludePeer: peer });
 
 				context.handled = true;
 
@@ -58,10 +62,12 @@ export const createLobbyPeerMiddleware = ({ room }: { room: Room; }): Middleware
 
 				peer.audioOnly = audioOnly;
 
-				room.notifyPeers('lobby:changeAudioOnly', {
-					peerId: peer.id,
-					audioOnly
-				}, peer);
+				room.notifyPeers({ method: 'lobby:changeAudioOnly',
+					data: {
+						peerId: peer.id,
+						audioOnly
+					},
+					excludePeer: peer });
 
 				context.handled = true;
 

--- a/src/middlewares/lockMiddleware.ts
+++ b/src/middlewares/lockMiddleware.ts
@@ -28,9 +28,11 @@ export const createLockMiddleware = ({ room }: { room: Room; }): Middleware<Peer
 
 				room.locked = true;
 
-				room.notifyPeers('lockRoom', {
-					peerId: peer.id,
-				}, peer);
+				room.notifyPeers({ method: 'lockRoom',
+					data: {
+						peerId: peer.id,
+					},
+					excludePeer: peer });
 
 				context.handled = true;
 
@@ -43,9 +45,11 @@ export const createLockMiddleware = ({ room }: { room: Room; }): Middleware<Peer
 
 				room.locked = false;
 
-				room.notifyPeers('unlockRoom', {
-					peerId: peer.id,
-				}, peer);
+				room.notifyPeers({ method: 'unlockRoom',
+					data: {
+						peerId: peer.id,
+					},
+					excludePeer: peer });
 
 				room.promoteAllPeers();
 				

--- a/src/middlewares/moderatorMiddleware.ts
+++ b/src/middlewares/moderatorMiddleware.ts
@@ -44,7 +44,7 @@ export const createModeratorMiddleware = ({ room }: { room: Room; }): Middleware
 					hasPermission(room, giveRolePeer, Permission.PROMOTE_PEER);
 
 				giveRolePeer.addRole(userRole);
-				room.notifyPeers('gotRole', { peerId: peer.id, roleId: userRole.id });
+				room.notifyPeers({ method: 'gotRole', data: { peerId: peer.id, roleId: userRole.id } });
 
 				if (
 					!room.lobbyPeers.empty &&
@@ -81,10 +81,11 @@ export const createModeratorMiddleware = ({ room }: { room: Room; }): Middleware
 
 				removeRolePeer.removeRole(userRole);
 
-				room.notifyPeers('lostRole', {
-					peerId: peer.id,
-					roleId: userRole.id
-				});
+				room.notifyPeers({ method: 'lostRole',
+					data: {
+						peerId: peer.id,
+						roleId: userRole.id
+					} });
 
 				context.handled = true;
 
@@ -96,7 +97,7 @@ export const createModeratorMiddleware = ({ room }: { room: Room; }): Middleware
 					throw new Error('peer not authorized');
 
 				room.chatHistory.length = 0;
-				room.notifyPeers('moderator:clearChat', {});
+				room.notifyPeers({ method: 'moderator:clearChat', data: {} });
 				context.handled = true;
 
 				break;
@@ -107,7 +108,7 @@ export const createModeratorMiddleware = ({ room }: { room: Room; }): Middleware
 					throw new Error('peer not authorized');
 
 				room.fileHistory.length = 0;
-				room.notifyPeers('moderator:clearFiles', {});
+				room.notifyPeers({ method: 'moderator:clearFiles', data: {} });
 				context.handled = true;
 
 				break;
@@ -133,7 +134,7 @@ export const createModeratorMiddleware = ({ room }: { room: Room; }): Middleware
 				if (!hasPermission(room, peer, Permission.MODERATE_ROOM))
 					throw new Error('peer not authorized');
 
-				room.notifyPeers('moderator:mute', {});
+				room.notifyPeers({ method: 'moderator:mute', data: {} });
 				context.handled = true;
 
 				break;
@@ -159,7 +160,7 @@ export const createModeratorMiddleware = ({ room }: { room: Room; }): Middleware
 				if (!hasPermission(room, peer, Permission.MODERATE_ROOM))
 					throw new Error('peer not authorized');
 
-				room.notifyPeers('moderator:stopVideo', {});
+				room.notifyPeers({ method: 'moderator:stopVideo', data: {} });
 				context.handled = true;
 
 				break;
@@ -185,7 +186,7 @@ export const createModeratorMiddleware = ({ room }: { room: Room; }): Middleware
 				if (!hasPermission(room, peer, Permission.MODERATE_ROOM))
 					throw new Error('peer not authorized');
 
-				room.notifyPeers('moderator:stopScreenSharing', {});
+				room.notifyPeers({ method: 'moderator:stopScreenSharing', data: {} });
 				context.handled = true;
 
 				break;
@@ -195,7 +196,7 @@ export const createModeratorMiddleware = ({ room }: { room: Room; }): Middleware
 				if (!hasPermission(room, peer, Permission.MODERATE_ROOM))
 					throw new Error('peer not authorized');
 
-				room.notifyPeers('moderator:kick', {});
+				room.notifyPeers({ method: 'moderator:kick', data: {} });
 				room.close();
 				context.handled = true;
 

--- a/src/middlewares/peerMiddleware.ts
+++ b/src/middlewares/peerMiddleware.ts
@@ -22,10 +22,12 @@ export const createPeerMiddleware = ({ room }: { room: Room; }): Middleware<Peer
 
 				peer.displayName = displayName;
 
-				room.notifyPeers('changeDisplayName', {
-					peerId: peer.id,
-					displayName
-				}, peer);
+				room.notifyPeers({ method: 'changeDisplayName',
+					data: {
+						peerId: peer.id,
+						displayName
+					},
+					excludePeer: peer });
 
 				context.handled = true;
 
@@ -37,10 +39,12 @@ export const createPeerMiddleware = ({ room }: { room: Room; }): Middleware<Peer
 
 				peer.picture = picture;
 
-				room.notifyPeers('changePicture', {
-					peerId: peer.id,
-					picture
-				}, peer);
+				room.notifyPeers({ method: 'changePicture',
+					data: {
+						peerId: peer.id,
+						picture
+					},
+					excludePeer: peer });
 
 				context.handled = true;
 
@@ -52,11 +56,13 @@ export const createPeerMiddleware = ({ room }: { room: Room; }): Middleware<Peer
 
 				peer.raisedHand = raisedHand;
 
-				room.notifyPeers('raisedHand', {
-					peerId: peer.id,
-					raisedHand,
-					raisedHandTimestamp: peer.raisedHandTimestamp
-				}, peer);
+				room.notifyPeers({ method: 'raisedHand',
+					data: {
+						peerId: peer.id,
+						raisedHand,
+						raisedHandTimestamp: peer.raisedHandTimestamp
+					},
+					excludePeer: peer });
 
 				context.handled = true;
 
@@ -70,7 +76,7 @@ export const createPeerMiddleware = ({ room }: { room: Room; }): Middleware<Peer
 
 				if (escapeMeeting) {
 					if (!room.peers.items.some((p) => !p.escapeMeeting)) {
-						room.notifyPeers('escapeMeeting', {});
+						room.notifyPeers({ method: 'escapeMeeting', data: {} });
 
 						room.close();
 					}


### PR DESCRIPTION
This PR will add the option to ignore breakout rooms when calling `Room.notifyPeers()
`
I want to use it for active speaker detection to avoid unnecessary overhead traffic.
As the function would have 4 positional arguments I thought it was a good idea to move to interface object instead.

I added unit-tests to validate functionality.