### PR TITLE
build/remove-stupid-ci-skip [skip ci]

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, '#skip') }}
     strategy:
       matrix:
         node-version: [18.x]


### PR DESCRIPTION
This PR will:
* Remove a stupid ci skip line in github workflows