### PR TITLE
feat/non-media-join

### DIFF
--- a/src/Peer.ts
+++ b/src/Peer.ts
@@ -79,13 +79,6 @@ export class Peer extends EventEmitter {
 	public routerId?: string;
 	public rtpCapabilities?: RtpCapabilities;
 	public sctpCapabilities?: SctpCapabilities;
-
-	// eslint-disable-next-line no-unused-vars
-	public resolveRouterReady!: (router: Router) => void;
-	public routerReady: Promise<Router> = new Promise<Router>((resolve) => {
-		this.resolveRouterReady = resolve;
-	});
-
 	public transports = new Map<string, WebRtcTransport>();
 	public consumers = new Map<string, Consumer>();
 	public producers = new Map<string, Producer>();
@@ -93,6 +86,7 @@ export class Peer extends EventEmitter {
 	public dataProducers = new Map<string, DataProducer>();
 	#sessionId: string;
 	public pipeline = Pipeline<PeerContext>();
+	public router?: Router;
 
 	constructor({
 		id,

--- a/src/common/consuming.ts
+++ b/src/common/consuming.ts
@@ -44,23 +44,17 @@ export const createConsumer = async (
 	producerPeer: Peer,
 	producer: Producer,
 ): Promise<void> => {
-	const [ consumerRouter, producerRouter ] = await Promise.all([
-		consumerPeer.routerReady,
-		producerPeer.routerReady,
-	]);
+	if (!consumerPeer.router) return logger.warn('Peer %s has no router assigned', consumerPeer.id);
+	if (!producerPeer.router) return logger.warn('Peer %s has no router assigned', producerPeer.id);
 
-	if (
-		!producerRouter ||
-		!consumerRouter ||
-		!consumerPeer.rtpCapabilities
-	)
+	if (!consumerPeer.rtpCapabilities)
 		return logger.warn(
 			'createConsumer() cannot consume [producerPeerId: %s, producerId: %s]',
 			producerPeer.id,
 			producer.id
 		);
 
-	const canConsume = await producerRouter.canConsume({
+	const canConsume = await producerPeer.router.canConsume({
 		producerId: producer.id,
 		rtpCapabilities: consumerPeer.rtpCapabilities
 	});
@@ -80,7 +74,7 @@ export const createConsumer = async (
 
 	try {
 		// This will wait for the pipe to be ready if it's not already
-		await checkPipe(producer, consumerRouter, producerRouter);
+		await checkPipe(producer, consumerPeer.router, producerPeer.router);
 
 		const consumer = await consumingTransport.consume({
 			producerId: producer.id,
@@ -194,17 +188,8 @@ export const createDataConsumer = async (
 	producerPeer: Peer,
 	dataProducer: DataProducer,
 ): Promise<void> => {
-	const [ consumerRouter, producerRouter ] = await Promise.all([
-		consumerPeer.routerReady,
-		producerPeer.routerReady,
-	]);
-
-	if (!producerRouter || !consumerRouter)
-		return logger.warn(
-			'createDataConsumer() cannot consume [producerPeerId: %s, producerId: %s]',
-			producerPeer.id,
-			dataProducer.id
-		);
+	if (!consumerPeer.router) return logger.warn('createDataConsumer() Peer %s has no router assigned', consumerPeer.id);
+	if (!producerPeer.router) return logger.warn('createDataConsumer() Peer %s has no router assigned', producerPeer.id);
 
 	const consumingTransport = Array.from(consumerPeer.transports.values())
 		.find((t) => t.appData.consuming);
@@ -214,7 +199,7 @@ export const createDataConsumer = async (
 
 	try {
 		// This will wait for the pipe to be ready if it's not already
-		await checkDataPipe(dataProducer, consumerRouter, producerRouter);
+		await checkDataPipe(dataProducer, consumerPeer.router, producerPeer.router);
 
 		const dataConsumer = await consumingTransport.consumeData({
 			dataProducerId: dataProducer.id,

--- a/src/middlewares/breakoutMiddleware.ts
+++ b/src/middlewares/breakoutMiddleware.ts
@@ -146,7 +146,7 @@ export const createBreakoutMiddleware = ({ room }: { room: Room; }): Middleware<
 			peer.notify({ method: 'sessionIdChanged', data: { sessionId: roomToJoin.sessionId } });
 
 		// Create consumers for the peer in the new room
-		createConsumers(room, peer);
+		peer.router && createConsumers(room, peer);
 	};
 
 	return middleware;

--- a/src/middlewares/initialMediaMiddleware.ts
+++ b/src/middlewares/initialMediaMiddleware.ts
@@ -24,8 +24,7 @@ export const createInitialMediaMiddleware = ({ room }: { room: Room; }): Middlew
 
 		switch (message.method) {
 			case 'retryConnection': {
-				if (!peer.router)
-					await room.retryAssignRouter(peer);
+				await room.retryAssignRouter(peer);
 				context.handled = true;
 				break;	
 			}

--- a/src/middlewares/initialMediaMiddleware.ts
+++ b/src/middlewares/initialMediaMiddleware.ts
@@ -2,6 +2,7 @@ import { Logger, Middleware } from 'edumeet-common';
 import { thisSession } from '../common/checkSessionId';
 import { PeerContext } from '../Peer';
 import Room from '../Room';
+import { createConsumers } from '../common/consuming';
 
 const logger = new Logger('InitialMediaMiddleware');
 
@@ -22,10 +23,26 @@ export const createInitialMediaMiddleware = ({ room }: { room: Room; }): Middlew
 			return next();
 
 		switch (message.method) {
-			case 'getRouterRtpCapabilities': {
-				const router = await peer.routerReady;
+			case 'retryConnection': {
+				if (!peer.router)
+					await room.retryAssignRouter(peer);
+				context.handled = true;
+				break;	
+			}
+			case 'rtpCapabilities': {
+				const { rtpCapabilities } = message.data;
 
-				response.routerRtpCapabilities = router.rtpCapabilities;
+				if (!rtpCapabilities) throw new Error('missing rtpCapabilities');
+
+				peer.rtpCapabilities = rtpCapabilities;
+				context.handled = true;
+				createConsumers(room, peer);
+				break;
+			}
+			case 'getRouterRtpCapabilities': {
+				if (!peer.router) return logger.warn('Peer %s has no router assigned', peer.id);
+
+				response.routerRtpCapabilities = peer.router.rtpCapabilities;
 				context.handled = true;
 
 				break;
@@ -39,9 +56,9 @@ export const createInitialMediaMiddleware = ({ room }: { room: Room; }): Middlew
 					sctpCapabilities,
 				} = message.data;
 
-				const router = await peer.routerReady;
+				if (!peer.router) return logger.warn('Peer %s has no router assigned', peer.id);
 
-				const transport = await router.createWebRtcTransport({
+				const transport = await peer.router.createWebRtcTransport({
 					forceTcp,
 					sctpCapabilities,
 					appData: {

--- a/src/middlewares/joinMiddleware.ts
+++ b/src/middlewares/joinMiddleware.ts
@@ -1,7 +1,6 @@
 import { Logger, Middleware } from 'edumeet-common';
 import { Permission } from '../common/authorization';
 import { thisSession } from '../common/checkSessionId';
-import { createConsumers } from '../common/consuming';
 import { PeerContext } from '../Peer';
 import Room from '../Room';
 
@@ -28,15 +27,10 @@ export const createJoinMiddleware = ({ room }: { room: Room; }): Middleware<Peer
 				const {
 					displayName,
 					picture,
-					rtpCapabilities,
 				} = message.data;
-
-				if (!rtpCapabilities)
-					throw new Error('missing rtpCapabilities');
 
 				peer.displayName = displayName;
 				peer.picture = picture;
-				peer.rtpCapabilities = rtpCapabilities;
 
 				const lobbyPeers = peer.hasPermission(Permission.PROMOTE_PEER) ?
 					room.lobbyPeers.items.map((p) => (p.peerInfo)) : [];
@@ -50,8 +44,6 @@ export const createJoinMiddleware = ({ room }: { room: Room; }): Middleware<Peer
 
 				room.joinPeer(peer);
 				context.handled = true;
-
-				createConsumers(room, peer);
 
 				break;
 			}


### PR DESCRIPTION
closes #69 

This PR will decouple room join from media join.

You can bring up the websocket to room-serve service, chat with peers etc, even though media is not setup, e.g. we couldn't get a router, timeout from media-node etc. Media connection can then be retried until it's available.

Depends on https://github.com/edumeet/edumeet-client/pull/125