### PR TITLE
Fix/close observer before router

### DIFF
--- a/__tests__/unit-tests/Room.ts
+++ b/__tests__/unit-tests/Room.ts
@@ -7,6 +7,7 @@ import { Config } from '../../src/Config';
 import { KDTree } from 'edumeet-common';
 import { ActiveSpeakerObserver } from '../../src/media/ActiveSpeakerObserver';
 import MediaNode from '../../src/media/MediaNode';
+import { setTimeout } from 'timers/promises';
 
 describe('Room', () => {
 	let room1: Room;
@@ -80,9 +81,11 @@ describe('Room', () => {
 			spyAdd = jest.spyOn(room1.routers, 'add');
 		});
 
-		it('close() - should close router', () => {
+		it('close() - should close router', async () => {
 			room1.addRouter(router);
 			room1.close();
+			expect(spyClose).not.toHaveBeenCalled();
+			await setTimeout(50);
 			expect(spyClose).toHaveBeenCalled();
 		});
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@feathersjs/feathers": "^5.0.5",
 		"@feathersjs/socketio-client": "^5.0.5",
 		"debug": "^4.3.4",
-		"edumeet-common": "edumeet/edumeet-common#0.5.0",
+		"edumeet-common": "edumeet/edumeet-common#0.6.0",
 		"geoip-lite": "^1.4.7",
 		"jsonwebtoken": "^9.0.0",
 		"socket.io": "^4.6.1",

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -147,7 +147,7 @@ export default class Room extends EventEmitter {
 	}
 
 	@skipIfClosed
-	public async close() {
+	public close() {
 		logger.debug('close() [id: %s]', this.id);
 
 		this.closed = true;
@@ -157,20 +157,18 @@ export default class Room extends EventEmitter {
 		this.lobbyPeers.items.forEach((p) => p.close());
 
 		this.breakoutRooms.forEach((r) => r.close());
-		try {
-			const observer = await timeoutPromise(this.activeSpeakerObserverReady, 1000);
-
-			observer.close();
-		} catch (error) {
-			logger.error('close() [error: %o]', error);
-		}
-		this.routers.items.forEach((r) => r.close());
-
+		timeoutPromise(this.activeSpeakerObserverReady, 1000).then((o) => o.close())
+			.catch((error) => {
+				logger.error('close() [error: %o]', error);
+			})
+			.finally(() => {
+				this.routers.items.forEach((r) => r.close());
+				this.routers.clear();
+			});
 		this.pendingPeers.clear();
 		this.peers.clear();
 		this.lobbyPeers.clear();
 		this.breakoutRooms.clear();
-		this.routers.clear();
 
 		this.emit('close');
 	}

--- a/src/media/MediaNode.ts
+++ b/src/media/MediaNode.ts
@@ -116,6 +116,7 @@ export default class MediaNode extends EventEmitter {
 		} catch (error) {
 			this.#connection.close();
 			this.pendingRequests.delete(requestUUID);
+			logger.error('getRouter() [%o]', error);
 			this.#health.retryConnection();
 
 			throw error;
@@ -157,7 +158,7 @@ export default class MediaNode extends EventEmitter {
 			return router;
 
 		} catch (error) {
-			logger.error(error);
+			logger.error('getRouter() [%o]', error);
 			this.#health.retryConnection();
 			throw error;
 		} finally {
@@ -229,6 +230,7 @@ export default class MediaNode extends EventEmitter {
 			
 		} catch (error) {
 			if (error instanceof SocketTimeoutError) {
+				logger.error('request() [method: %s, %o]', request.method, error);
 				this.#health.retryConnection();
 			}
 			throw error;

--- a/src/media/Producer.ts
+++ b/src/media/Producer.ts
@@ -2,8 +2,7 @@ import { EventEmitter } from 'events';
 import { Router } from './Router';
 import { RtpParameters } from 'mediasoup-client/lib/RtpParameters';
 import { ProducerScore } from '../common/types';
-import { Logger, skipIfClosed } from 'edumeet-common';
-import { MediaKind } from 'edumeet-common';
+import { Logger, skipIfClosed, MediaKind } from 'edumeet-common';
 import MediaNode from './MediaNode';
 
 const logger = new Logger('Producer');

--- a/src/middlewares/mediaMiddleware.ts
+++ b/src/middlewares/mediaMiddleware.ts
@@ -90,9 +90,11 @@ export const createMediaMiddleware = ({ room }: { room: Room; }): Middleware<Pee
 								await room.activeSpeakerObserverReady : 
 								await breakoutRoom?.activeSpeakerObserverReady;
 
-							await observer?.addProducer(producer);
+							if (!observer) throw new Error('No ActiveSpeakerObserver');
+
+							await observer.addProducer(producer);
 							producer.on('close', () => {
-								observer?.removeProducer(producer).catch((error) => logger.error(error));
+								observer.removeProducer(producer).catch((error) => logger.error('createMediaMiddleware() [%o]', error));
 							});
 						} catch (error) {
 							logger.error('createMediaMiddleware() [%o]', error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1525,9 +1525,9 @@ ecdsa-sig-formatter@1.0.11:
   dependencies:
     safe-buffer "^5.0.1"
 
-edumeet-common@edumeet/edumeet-common#0.5.0:
-  version "0.5.0"
-  resolved "https://codeload.github.com/edumeet/edumeet-common/tar.gz/8aecc7f7b60b6772b2062d5bfa0e563f014739ff"
+edumeet-common@edumeet/edumeet-common#0.6.0:
+  version "0.6.0"
+  resolved "https://codeload.github.com/edumeet/edumeet-common/tar.gz/2a6a1080054846e500b3c297f2e00cb5f486e567"
   dependencies:
     debug "^4.3.4"
     socket.io-client "^4.6.1"


### PR DESCRIPTION
This PR will:
* improve debug logs
* close ActiveSpeakerObserver before router when closing room
* update edumeet-common version