### PR TITLE
Fix/consumer paused

### DIFF
--- a/src/common/consuming.ts
+++ b/src/common/consuming.ts
@@ -174,6 +174,7 @@ export const createConsumer = async (
 					kind: consumer.kind,
 					rtpParameters: consumer.rtpParameters,
 					producerPaused: consumer.producerPaused,
+					paused: consumer.paused,
 					appData: producer.appData,
 				}
 			});

--- a/src/media/MediaNodeConnection.ts
+++ b/src/media/MediaNodeConnection.ts
@@ -89,6 +89,7 @@ export class MediaNodeConnection extends EventEmitter {
 		this.#resolveReadyTimeoutHandle = setTimeout(() => { this.rejectReady('Timeout waiting for media-node connection'); }, this.#timeout);
 		
 		this.#socket.on('notification', async (notification) => {
+			logger.debug('"notification" recieved [notification: %o]', notification);
 			this.emit('load', notification.data?.load);
 
 			if (notification.method === 'mediaNodeReady') {


### PR DESCRIPTION
This PR will include consumer.paused property when notifying client about newConsumer.
We start video consumers as paused on server-side.
So the client needs to know that.

>As explained in the [transport.consume()](https://mediasoup.org/documentation/v3/mediasoup/api/#transport-consume) documentation, it's strongly recommended to create the server side consumer with paused: true and resume it once created in the remote endpoint.

https://mediasoup.org/documentation/v3/communication-between-client-and-server/#consuming-media
