### PR TITLE
Update mediasoup to version 3.15.8.

### DIFF
--- a/__tests__/unit-tests/WebRtcTransport.ts
+++ b/__tests__/unit-tests/WebRtcTransport.ts
@@ -6,7 +6,7 @@ import { KDPoint } from 'edumeet-common';
 import { Producer } from '../../src/media/Producer';
 import { Consumer } from '../../src/media/Consumer';
 import { WebRtcTransport } from '../../src/media/WebRtcTransport';
-import { DtlsParameters, IceCandidate, IceParameters } from 'mediasoup/node/lib/WebRtcTransport';
+import { DtlsParameters, IceCandidate, IceParameters } from 'mediasoup/types';
 
 const fakePoint = {} as unknown as KDPoint;
 const create = () => {

--- a/__tests__/unit-tests/media/DataConsumer.ts
+++ b/__tests__/unit-tests/media/DataConsumer.ts
@@ -3,7 +3,7 @@ import 'jest';
 import { DataConsumer } from '../../../src/media/DataConsumer';
 import { Router } from '../../../src/media/Router';
 import MediaNode from '../../../src/media/MediaNode';
-import { SctpStreamParameters } from 'mediasoup/node/lib/SctpParameters';
+import { SctpStreamParameters } from 'mediasoup/types';
 
 describe('Consumer', () => {
 	const dataConsumerId = 'id'; 

--- a/__tests__/unit-tests/media/Dataproducer.ts
+++ b/__tests__/unit-tests/media/Dataproducer.ts
@@ -3,7 +3,7 @@ import 'jest';
 import { DataProducer } from '../../../src/media/DataProducer';
 import { Router } from '../../../src/media/Router';
 import MediaNode from '../../../src/media/MediaNode';
-import { SctpStreamParameters } from 'mediasoup/node/lib/SctpParameters';
+import { SctpStreamParameters } from 'mediasoup/types';
 
 describe('DataProducer', () => {
 	const DATA_PRODUCER_ID = 'id';

--- a/__tests__/unit-tests/media/Router.ts
+++ b/__tests__/unit-tests/media/Router.ts
@@ -2,7 +2,7 @@ import 'jest';
 import { Router } from '../../../src/media/Router';
 import MediaNode from '../../../src/media/MediaNode';
 import { RtpCapabilities, RtpParameters } from 'mediasoup-client/lib/RtpParameters';
-import { SctpCapabilities } from 'mediasoup/node/lib/SctpParameters';
+import { SctpCapabilities } from 'mediasoup/types';
 import { Producer } from '../../../src/media/Producer';
 import { WebRtcTransport } from '../../../src/media/WebRtcTransport';
 import { PipeTransport } from '../../../src/media/PipeTransport';

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"geoip-lite": "^1.4.10",
 		"h264-profile-level-id": "^1.1.1",
 		"jsonwebtoken": "^9.0.2",
-		"mediasoup": "^3.14.14",
+		"mediasoup": "3.15.8",
 		"socket.io": "^4.8.0",
 		"socket.io-client": "^4.8.0"
 	},

--- a/src/Peer.ts
+++ b/src/Peer.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import { MediaSourceType, Role } from './common/types';
 import { Router } from './media/Router';
-import { RtpCapabilities, SctpCapabilities } from 'mediasoup/node/lib/types';
+import { RtpCapabilities, SctpCapabilities } from 'mediasoup/types';
 import { WebRtcTransport } from './media/WebRtcTransport';
 import { Consumer } from './media/Consumer';
 import { Producer } from './media/Producer';

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -20,9 +20,9 @@ import { MediaNode } from './media/MediaNode';
 import BreakoutRoom from './BreakoutRoom';
 import { Permission, isAllowed, updatePeerPermissions } from './common/authorization';
 import { safePromise } from './common/safePromise';
-import type { RtpCapabilities } from 'mediasoup/node/lib/RtpParameters';
+import type { RtpCapabilities } from 'mediasoup/types';
 import { IceServer, getCredentials, getIceServers } from './common/turnCredentials';
-import { SctpCapabilities } from 'mediasoup/node/lib/SctpParameters';
+import { SctpCapabilities } from 'mediasoup/types';
 import { Router } from './media/Router';
 
 const logger = new Logger('Room');

--- a/src/common/ortc.ts
+++ b/src/common/ortc.ts
@@ -7,7 +7,7 @@ import {
 	RtpCodecParameters,
 	RtpHeaderExtension,
 	RtpParameters
-} from 'mediasoup/node/lib/RtpParameters';
+} from 'mediasoup/types';
 
 /**
  * Validates RtpCapabilities. It may modify given data by adding missing

--- a/src/media/Consumer.ts
+++ b/src/media/Consumer.ts
@@ -3,7 +3,7 @@ import { Router } from './Router';
 import { ConsumerLayers, ConsumerScore } from '../common/types';
 import { Logger, skipIfClosed, MediaKind } from 'edumeet-common';
 import { MediaNode } from './MediaNode';
-import { RtpParameters } from 'mediasoup/node/lib/RtpParameters';
+import { RtpParameters } from 'mediasoup/types';
 
 const logger = new Logger('Consumer');
 

--- a/src/media/DataConsumer.ts
+++ b/src/media/DataConsumer.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { Router } from './Router';
 import { Logger, skipIfClosed } from 'edumeet-common';
 import { MediaNode } from './MediaNode';
-import { SctpStreamParameters } from 'mediasoup/node/lib/SctpParameters';
+import { SctpStreamParameters } from 'mediasoup/types';
 
 const logger = new Logger('DataConsumer');
 

--- a/src/media/DataProducer.ts
+++ b/src/media/DataProducer.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { Router } from './Router';
 import { Logger, skipIfClosed } from 'edumeet-common';
 import { MediaNode } from './MediaNode';
-import { SctpStreamParameters } from 'mediasoup/node/lib/SctpParameters';
+import { SctpStreamParameters } from 'mediasoup/types';
 
 const logger = new Logger('DataProducer');
 

--- a/src/media/PipeConsumer.ts
+++ b/src/media/PipeConsumer.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { Router } from './Router';
 import { Logger, skipIfClosed, MediaKind } from 'edumeet-common';
 import { MediaNode } from './MediaNode';
-import { RtpParameters } from 'mediasoup/node/lib/RtpParameters';
+import { RtpParameters } from 'mediasoup/types';
 
 const logger = new Logger('PipeConsumer');
 

--- a/src/media/PipeDataConsumer.ts
+++ b/src/media/PipeDataConsumer.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { Router } from './Router';
 import { Logger, skipIfClosed } from 'edumeet-common';
 import { MediaNode } from './MediaNode';
-import { SctpStreamParameters } from 'mediasoup/node/lib/SctpParameters';
+import { SctpStreamParameters } from 'mediasoup/types';
 
 const logger = new Logger('PipeDataConsumer');
 

--- a/src/media/PipeDataProducer.ts
+++ b/src/media/PipeDataProducer.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { Router } from './Router';
 import { Logger, skipIfClosed } from 'edumeet-common';
 import { MediaNode } from './MediaNode';
-import { SctpStreamParameters } from 'mediasoup/node/lib/SctpParameters';
+import { SctpStreamParameters } from 'mediasoup/types';
 
 const logger = new Logger('PipeDataProducer');
 

--- a/src/media/PipeProducer.ts
+++ b/src/media/PipeProducer.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 import { Router } from './Router';
 import { Logger, skipIfClosed, MediaKind } from 'edumeet-common';
 import { MediaNode } from './MediaNode';
-import { RtpParameters } from 'mediasoup/node/lib/RtpParameters';
+import { RtpParameters } from 'mediasoup/types';
 
 const logger = new Logger('PipeProducer');
 

--- a/src/media/PipeTransport.ts
+++ b/src/media/PipeTransport.ts
@@ -7,8 +7,7 @@ import { Logger, skipIfClosed, MediaKind } from 'edumeet-common';
 import { PipeDataProducer, PipeDataProducerOptions } from './PipeDataProducer';
 import { PipeDataConsumer, PipeDataConsumerOptions } from './PipeDataConsumer';
 import { MediaNode } from './MediaNode';
-import { RtpParameters } from 'mediasoup/node/lib/RtpParameters';
-import { SctpStreamParameters } from 'mediasoup/node/lib/SctpParameters';
+import { RtpParameters, SctpStreamParameters } from 'mediasoup/types';
 
 const logger = new Logger('PipeTransport');
 

--- a/src/media/Producer.ts
+++ b/src/media/Producer.ts
@@ -3,7 +3,7 @@ import { Router } from './Router';
 import { ProducerScore } from '../common/types';
 import { Logger, skipIfClosed, MediaKind } from 'edumeet-common';
 import { MediaNode } from './MediaNode';
-import { RtpParameters } from 'mediasoup/node/lib/RtpParameters';
+import { RtpParameters } from 'mediasoup/types';
 
 const logger = new Logger('Producer');
 

--- a/src/media/Router.ts
+++ b/src/media/Router.ts
@@ -14,8 +14,7 @@ import { DataConsumer } from './DataConsumer';
 import { ActiveSpeakerObserver, ActiveSpeakerObserverOptions } from './ActiveSpeakerObserver';
 import { AudioLevelObserver, AudioLevelObserverOptions } from './AudioLevelObserver';
 import { canConsume } from '../common/ortc';
-import { SctpCapabilities } from 'mediasoup/node/lib/SctpParameters';
-import { RtpCapabilities } from 'mediasoup/node/lib/RtpParameters';
+import { SctpCapabilities, RtpCapabilities } from 'mediasoup/types';
 import { Recorder, RecorderOptions } from './Recorder';
 
 const logger = new Logger('Router');

--- a/src/media/WebRtcTransport.ts
+++ b/src/media/WebRtcTransport.ts
@@ -7,9 +7,11 @@ import { DataProducer, DataProducerOptions } from './DataProducer';
 import { DataConsumer, DataConsumerOptions } from './DataConsumer';
 import { MediaKind } from 'edumeet-common';
 import { MediaNode } from './MediaNode';
-import { RtpCapabilities, RtpParameters } from 'mediasoup/node/lib/RtpParameters';
-import { SctpParameters, SctpStreamParameters } from 'mediasoup/node/lib/SctpParameters';
-import { DtlsParameters, IceCandidate, IceParameters } from 'mediasoup/node/lib/WebRtcTransport';
+import {
+	RtpCapabilities, RtpParameters,
+	SctpParameters, SctpStreamParameters,
+	DtlsParameters, IceCandidate, IceParameters,
+} from 'mediasoup/types';
 
 const logger = new Logger('WebRtcTransport');
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,10 +1,12 @@
-import { Worker } from 'mediasoup/node/lib/Worker';
-import { Router } from 'mediasoup/node/lib/Router';
-import { Transport } from 'mediasoup/node/lib/Transport';
-import { Producer } from 'mediasoup/node/lib/Producer';
-import { Consumer } from 'mediasoup/node/lib/Consumer';
-import { DataProducer } from 'mediasoup/node/lib/DataProducer';
-import { DataConsumer } from 'mediasoup/node/lib/DataConsumer';
+import {
+	Worker,
+	Router,
+	Transport,
+	Producer,
+	Consumer,
+	DataProducer,
+	DataConsumer
+} from 'mediasoup/types';
 import ServerManager from '../ServerManager';
 import ManagementService from '../ManagementService';
 


### PR DESCRIPTION
Mediasoup version 3.15 introduced changes to the type definitions, which prevent the current implementation from building.

This PR updates the import paths accordingly and bumps the mediasoup version to 3.15.8.

I chose not to upgrade to mediasoup 3.16.0 because it requires dropping Node 18 support. Dropping support for Node 18 may impact other parts of the project (e.g., the README).
Someone with deeper knowledge of edumeet should make that decision.