### PR TITLE
Improve geolocation, update TS types to node 24

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"test:watch": "jest --watch"
 	},
 	"devDependencies": {
-		"@tsconfig/node20": "^20.1.8",
+		"@tsconfig/node24": "^24.0.4",
 		"@types/debug": "^4.1.12",
 		"@types/geoip-lite": "^1.4.4",
 		"@types/jest": "^30.0.0",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "@tsconfig/node20/tsconfig.json",
+	"extends": "@tsconfig/node24/tsconfig.json",
 	"compilerOptions": {
 		"experimentalDecorators": true,
 		"resolveJsonModule": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -848,10 +848,10 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
-"@tsconfig/node20@^20.1.8":
-  version "20.1.8"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node20/-/node20-20.1.8.tgz#a11034b1f3362ffaeb7255f6c975040d8a395d70"
-  integrity sha512-Em+IdPfByIzWRRpqWL4Z7ArLHZGxmc36BxE3jCz9nBFSm+5aLaPMZyjwu4yetvyKXeogWcxik4L1jB5JTWfw7A==
+"@tsconfig/node24@^24.0.4":
+  version "24.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node24/-/node24-24.0.4.tgz#ae50cc6b3288c1010454f0ec4659b47b520ca1b1"
+  integrity sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==
 
 "@types/babel__core@^7.1.14":
   version "7.20.5"


### PR DESCRIPTION
Before: as soon as sticky distance > 1500 km, we always split room to a new node, even if the new node is only slightly closer.

Now: we only split if the best alternative is significantly closer (more than 25% shorter distance), which avoids pointless multi-node rooms.